### PR TITLE
drm/meson: Don't call canvas_setup unless the FB has actually changed

### DIFF
--- a/drivers/gpu/drm/drm_atomic_helper.c
+++ b/drivers/gpu/drm/drm_atomic_helper.c
@@ -1049,6 +1049,7 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 	for (i = 0; i < nplanes; i++) {
 		struct drm_plane_helper_funcs *funcs;
 		struct drm_plane *plane = old_state->planes[i];
+		struct drm_plane_state *old_plane_state;
 
 		if (!plane)
 			continue;
@@ -1058,7 +1059,9 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 		if (!funcs)
 			continue;
 
-		funcs->atomic_update(plane);
+		old_plane_state = old_state->plane_states[i];
+
+		funcs->atomic_update(plane, old_plane_state);
 	}
 
 	for (i = 0; i < ncrtcs; i++) {

--- a/drivers/gpu/drm/drm_atomic_helper.c
+++ b/drivers/gpu/drm/drm_atomic_helper.c
@@ -1014,18 +1014,18 @@ EXPORT_SYMBOL(drm_atomic_helper_prepare_planes);
 /**
  * drm_atomic_helper_commit_planes - commit plane state
  * @dev: DRM device
- * @state: atomic state
+ * @old_state: atomic state object with old state structures
  *
  * This function commits the new plane state using the plane and atomic helper
  * functions for planes and crtcs. It assumes that the atomic state has already
  * been pushed into the relevant object state pointers, since this step can no
  * longer fail.
  *
- * It still requires the global state object @state to know which planes and
+ * It still requires the global state object @old_state to know which planes and
  * crtcs need to be updated though.
  */
 void drm_atomic_helper_commit_planes(struct drm_device *dev,
-				     struct drm_atomic_state *state)
+				     struct drm_atomic_state *old_state)
 {
 	int nplanes = dev->mode_config.num_total_plane;
 	int ncrtcs = dev->mode_config.num_crtc;
@@ -1033,7 +1033,7 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 
 	for (i = 0; i < ncrtcs; i++) {
 		struct drm_crtc_helper_funcs *funcs;
-		struct drm_crtc *crtc = state->crtcs[i];
+		struct drm_crtc *crtc = old_state->crtcs[i];
 
 		if (!crtc)
 			continue;
@@ -1048,7 +1048,7 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 
 	for (i = 0; i < nplanes; i++) {
 		struct drm_plane_helper_funcs *funcs;
-		struct drm_plane *plane = state->planes[i];
+		struct drm_plane *plane = old_state->planes[i];
 
 		if (!plane)
 			continue;
@@ -1063,7 +1063,7 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 
 	for (i = 0; i < ncrtcs; i++) {
 		struct drm_crtc_helper_funcs *funcs;
-		struct drm_crtc *crtc = state->crtcs[i];
+		struct drm_crtc *crtc = old_state->crtcs[i];
 
 		if (!crtc)
 			continue;

--- a/drivers/gpu/drm/drm_atomic_helper.c
+++ b/drivers/gpu/drm/drm_atomic_helper.c
@@ -1055,7 +1055,7 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
 
 		funcs = plane->helper_private;
 
-		if (!funcs || !funcs->atomic_update)
+		if (!funcs)
 			continue;
 
 		funcs->atomic_update(plane);

--- a/drivers/gpu/drm/drm_plane_helper.c
+++ b/drivers/gpu/drm/drm_plane_helper.c
@@ -438,7 +438,7 @@ int drm_plane_helper_commit(struct drm_plane *plane,
 			crtc_funcs[i]->atomic_begin(crtc[i]);
 	}
 
-	plane_funcs->atomic_update(plane);
+	plane_funcs->atomic_update(plane, plane_state);
 
 	for (i = 0; i < 2; i++) {
 		if (crtc_funcs[i] && crtc_funcs[i]->atomic_flush)

--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -352,8 +352,6 @@ static void meson_plane_atomic_update(struct drm_plane *plane, struct drm_plane_
 	}
 
 	if (visible) {
-		struct drm_gem_cma_object *cma_bo;
-
 		/* If we're interlacing, then figure out what strategy we're
 		 * going to use. */
 		if (state->crtc->mode.flags & DRM_MODE_FLAG_INTERLACE) {
@@ -367,15 +365,19 @@ static void meson_plane_atomic_update(struct drm_plane *plane, struct drm_plane_
 			meson_plane->interlacing_strategy = MESON_INTERLACING_STRATEGY_NONE;
 		}
 
-		cma_bo = drm_fb_cma_get_gem_obj(state->fb, 0);
+		if (state->fb != old_state->fb) {
+			struct drm_gem_cma_object *cma_bo;
 
-		/* Swap out the OSD canvas with the new addr. */
-		canvas_setup(meson_plane->def->canvas_index,
-			     cma_bo->paddr,
-			     state->fb->pitches[0],
-			     state->fb->height,
-			     MESON_CANVAS_WRAP_NONE,
-			     MESON_CANVAS_BLKMODE_LINEAR);
+			cma_bo = drm_fb_cma_get_gem_obj(state->fb, 0);
+
+			/* Swap out the OSD canvas with the new addr. */
+			canvas_setup(meson_plane->def->canvas_index,
+				     cma_bo->paddr,
+				     state->fb->pitches[0],
+				     state->fb->height,
+				     MESON_CANVAS_WRAP_NONE,
+				     MESON_CANVAS_BLKMODE_LINEAR);
+		}
 
 		/* Enable OSD and BLK0. */
 		meson_plane->reg.CTRL_STAT = ((1 << 21) |    /* Enable OSD */

--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -303,7 +303,7 @@ static inline int64_t fixed16_to_int(int64_t value)
 	return value >> 16;
 }
 
-static void meson_plane_atomic_update(struct drm_plane *plane)
+static void meson_plane_atomic_update(struct drm_plane *plane, struct drm_plane_state *old_state)
 {
 	struct meson_plane *meson_plane = to_meson_plane(plane);
 	struct drm_plane_state *state = plane->state;

--- a/include/drm/drm_plane_helper.h
+++ b/include/drm/drm_plane_helper.h
@@ -64,7 +64,8 @@ struct drm_plane_helper_funcs {
 
 	int (*atomic_check)(struct drm_plane *plane,
 			    struct drm_plane_state *state);
-	void (*atomic_update)(struct drm_plane *plane);
+	void (*atomic_update)(struct drm_plane *plane,
+			      struct drm_plane_state *old_state);
 };
 
 static inline void drm_plane_helper_add(struct drm_plane *plane,

--- a/include/drm/drm_plane_helper.h
+++ b/include/drm/drm_plane_helper.h
@@ -52,7 +52,7 @@ extern int drm_crtc_init(struct drm_device *dev,
  * @prepare_fb: prepare a framebuffer for use by the plane
  * @cleanup_fb: cleanup a framebuffer when it's no longer used by the plane
  * @atomic_check: check that a given atomic state is valid and can be applied
- * @atomic_update: apply an atomic state to the plane
+ * @atomic_update: apply an atomic state to the plane (mandatory)
  *
  * The helper operations are called by the mid-layer CRTC helper.
  */

--- a/include/drm/drm_plane_helper.h
+++ b/include/drm/drm_plane_helper.h
@@ -49,6 +49,10 @@ extern int drm_crtc_init(struct drm_device *dev,
 
 /**
  * drm_plane_helper_funcs - helper operations for CRTCs
+ * @prepare_fb: prepare a framebuffer for use by the plane
+ * @cleanup_fb: cleanup a framebuffer when it's no longer used by the plane
+ * @atomic_check: check that a given atomic state is valid and can be applied
+ * @atomic_update: apply an atomic state to the plane
  *
  * The helper operations are called by the mid-layer CRTC helper.
  */


### PR DESCRIPTION
@dsd spotted this when debugging the DRM driver and asked me if it was needed. It's not, but there's no reason to do extra work, so let's fizzle this out.

It's also another quick opportunity to get ourselves on a more recent DRM API.
