### PR TITLE
meson: DTS: cleanup and remove eMMC node

### DIFF
--- a/arch/arm/boot/dts/meson8b_m201_1G.dts
+++ b/arch/arm/boot/dts/meson8b_m201_1G.dts
@@ -201,20 +201,6 @@
 			irq_out = <5>;
 			card_type = <5>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
 		};
-
-		emmc {
-			status = "ok";
-			port = <2>; /* 0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-			pinname = "emmc";
-			ocr_avail = <0x200000>; /* VDD voltage 3.3 ~ 3.4 */
-			caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE","MMC_CAP_ERASE", "MMC_CAP_HW_RESET";
-			f_min = <300000>;
-			f_max = <50000000>;
-			f_max_w = <50000000>;
-			max_req_size = <0x20000>; /* 128KB*/
-			gpio_dat3 = "BOOT_3";
-			card_type = <1>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-		};
 	};
 
 	i2c@c8100500{ /* I2C-AO */

--- a/arch/arm/boot/dts/meson8b_m201_1G.dts
+++ b/arch/arm/boot/dts/meson8b_m201_1G.dts
@@ -5,200 +5,106 @@
 	interrupt-parent = <&gic>;
 	#address-cells = <1>;
 	#size-cells = <1>;
-	
-    cpus {
-        #address-cells = <1>;
-        #size-cells = <0>;
-        cpu@0 {
-        	device_type = "cpu";
-        	compatible = "arm,cortex-a5";
-        	reg = <0x200>;
-        };
-        cpu@1 {
-        	device_type = "cpu";
-        	compatible = "arm,cortex-a5";
-        	reg = <0x1>;
-        };
-        cpu@2 {
-        	device_type = "cpu";
-        	compatible = "arm,cortex-a5";
-        	reg = <0x2>;
-        };
-        cpu@3 {
-        	device_type = "cpu";
-        	compatible = "arm,cortex-a5";
-        	reg = <0x3>;
-        };
-    };
 
-    cache-controller {
-          compatible = "arm,meson-pl310-cache";
-          reg = <0xc4200000 0x1000>;
-          arm,data-latency = <3 3 3>;
-          arm,tag-latency = <2 2 2>;
-          arm,filter-ranges = <0x100000 0xc0000000>;
-          cache-unified;
-          cache-level = <2>;
-          aux-instruction_prefetch;
-          aux-data_prefetch;
-          aux-ns_lockdown;
-          aux-force_no_write_alloc;
-          aux-cache_replace_policy_round_robin;
-          aux-early_write_response;
-          aux-full_line_of_zero;
-          aux-ns_int_ctrl;
-          aux-share_override;
-          prefetch-double_line_fill;
-          prefetch-prefetch_drop;
-          prefetch-prefetch_offset = <7>;
-    };
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-	memory{
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a5";
+			reg = <0x200>;
+	        };
+
+	        cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a5";
+			reg = <0x1>;
+	        };
+
+	        cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a5";
+			reg = <0x2>;
+	        };
+
+	        cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a5";
+			reg = <0x3>;
+	        };
+	};
+
+	cache-controller {
+		compatible = "arm,meson-pl310-cache";
+		reg = <0xc4200000 0x1000>;
+		arm,data-latency = <3 3 3>;
+		arm,tag-latency = <2 2 2>;
+		arm,filter-ranges = <0x100000 0xc0000000>;
+		cache-unified;
+		cache-level = <2>;
+		aux-instruction_prefetch;
+		aux-data_prefetch;
+		aux-ns_lockdown;
+		aux-force_no_write_alloc;
+		aux-cache_replace_policy_round_robin;
+		aux-early_write_response;
+		aux-full_line_of_zero;
+		aux-ns_int_ctrl;
+		aux-share_override;
+		prefetch-double_line_fill;
+		prefetch-prefetch_drop;
+		prefetch-prefetch_offset = <7>;
+	};
+
+	memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		device_type = "memory";
 		aml_reserved_start = <0x06000000>; /**reserved memory start */
 		aml_reserved_end = <0x05000000>;/**reserved memory end : dtb start for uboot*/
 		phys_offset = <0x00200000>;
 		linux,total-memory = <0x3fe00000>;
-      #address-cells = <1>;
-      #size-cells = <1>;
-
-//      cma_0:region@0 {
-//         region_name = "cma_0";
-//         reg = <0 0x02a00000>;
-//         linux,contiguous-region;
-//      };
 	};
-	gic:interrupt-controller{
-        compatible = "arm,cortex-a9-gic";
-        reg = <0xc4301000 0x1000
-               0xc4300100 0x0100>;
-        interrupt-controller;
-        #interrupt-cells = <3>;
-        #address-cells = <0>;
-    };
-    
-    vpu{
+
+	gic:interrupt-controller {
+		compatible = "arm,cortex-a9-gic";
+		reg = <0xc4301000 0x1000
+		       0xc4300100 0x0100>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <0>;
+	};
+
+	vpu {
 		compatible = "amlogic,vpu";
-		dev_name = "vpu";	
+		dev_name = "vpu";
 		status = "ok";
 		clk_level = <3>;
-		/**    	0: 106.25M		1: 127.5M		2: 159.375M
-				3: 182.15M		4: 212.5M	 */
 	};
-	
-//	mesonfb{
-//		compatible = "amlogic,mesonfb";
-//		dev_name = "mesonfb";
-//		status = "okay";
-//	   	reserve-memory = <0x01800000  0x00100000>;
-//	   	reserve-iomap = "true";
-//                vmode = <3>; /**0:VMODE_720P 1:VMODE_LCD  2:VMODE_LVDS_1080P 3:VMODE_1080P*/
-//		scale_mode = <1>; /*0:default 1:new*/
-//		4k2k_fb = <0>;
-// 		display_size_default = <1920 1080 1920 3240 32>; //1920*1080*4*3 = 0x17BB000
-//	};
 
-//  deinterlace{
-//		compatible = "amlogic,deinterlace";
-//		dev_name = "deinterlace";
-//		status = "ok";
-//		reserve-memory = <0x02100000>; //10x1920x1088x3/2=33M
-//	};
+	ion_dev {
+		compatible = "amlogic,ion_dev";
+		dev_name = "ion_dev";
+		status = "ok";
+		share-memory-name = "ppmgr0";
+		share-memory-offset = <0>;
+		share-memory-size = <0x01000000>;
+	};
 
-//	mesonstream{
-//		compatible = "amlogic,mesonstream";
-//		dev_name = "mesonstream.0";
-//		status = "okay";
-//		reserve-memory = <0x02000000>; // 32M
-//		reserve-iomap = "true";
-//	};
-
-//      vdec{
-//              compatible = "amlogic,vdec";
-//              dev_name = "vdec.0";
-//              status = "okay";
-//              reserve-memory = <0x04000000>; // 64M
-//              reserve-iomap = "true";
-//      };
-
-//  ppmgr{
-//		compatible = "amlogic,ppmgr";
-//		dev_name = "ppmgr";
-//		status = "okay";
-//		reserve-memory = <0x01000000>; // 16M
-//	};
-
-//  amvenc_avc{
-//		compatible = "amlogic,amvenc_avc";
-//		dev_name = "amvenc_avc.0";
-//		status = "okay";
-//		linux,contiguous-region = <&cma_0>;
-//		reserve-iomap = "true";
-//	};
-
-//    amvdec_656in{
-//		compatible = "amlogic,amvdec_656in";
-//		dev_name = "amvdec_656in";
-//		status = "ok";
-//		reg = <0x1e400000 0x00100000>;
-//	};
-//	
-//    vdin0{
-//       compatible = "amlogic,vdin";
-//        dev_name = "vdin0";
-//        status = "ok";
-//	 reserve-memory = <0x04000000>;
-//        irq = <115>;
-//        vdin_id = <0>;
-//	};
-	
-//    vdin1{
-//        compatible = "amlogic,vdin";
-//       dev_name = "vdin1";
-//        status = "ok";
-//        reserve-memory = <0x01000000>;
-//	  miracast_size = <1920 1080>;//1920x1080x2x4=17M
-//	  reserve-iomap = "true";
-//        irq = <117>;
-//        vdin_id = <1>;
-//	};
-
-//    amlvideo2{
-//		compatible = "amlogic,amlvideo2";
-//		dev_name = "amlvideo2.0";
-//		status = "okay";
-//		reserve-memory = <0x01800000>;
-//		reserve-iomap = "true";
-//	};
-
-//    vm{
-//		compatible = "amlogic,vm";
-//		dev_name = "vm.0";
-//		status = "okay";
-//		reserve-memory = <0x01800000>;
-//		reserve-iomap = "true";
-//	};
-
-    ion_dev{
-        compatible = "amlogic,ion_dev";
-        dev_name = "ion_dev";
-        status = "ok";
-        share-memory-name = "ppmgr0";
-        share-memory-offset = <0>;
-        share-memory-size = <0x01000000>; //16M
-    };
-	mesonvout{
+	mesonvout {
 		compatible = "amlogic,mesonvout";
 		dev_name = "mesonvout";
 		status = "okay";
 	};
 
-    rtc{
+	rtc {
 		compatible = "amlogic,aml_rtc";
 		status = "okay";
 	};
 
-	uart_ao{
+	uart_ao {
 		compatible = "amlogic,aml_uart";
 		port_name = "uart_ao";
 		status = "okay";
@@ -206,46 +112,45 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&ao_uart_pins>;
 	};
-	
-	uart_0{
+
+	uart_0 {
 		compatible = "amlogic,aml_uart";
 		port_name = "uart_a";
 		status = "okay";
 		dev_name = "uart_0";
-//    	pinctrl-names = "default";
-//    	pinctrl-0 = <&a_uart_pins>;
 	};
-	
-	uart_1{
+
+	uart_1 {
 		compatible = "amlogic,aml_uart";
 		port_name = "uart_b";
 		status = "okay";
 		dev_name = "uart_1";
-        pinctrl-names = "default";
-        pinctrl-0 = <&b_uart_pins>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&b_uart_pins>;
 	};
-	
-	uart_2{
+
+	uart_2 {
 		compatible = "amlogic,aml_uart";
 		port_name = "uart_c";
 		status = "disabled";
 		dev_name = "uart_2";
 	};
-	
-	uart_3{
+
+	uart_3 {
 		compatible = "amlogic,aml_uart";
 		port_name = "uart_d";
 		status = "ok";
 		dev_name = "uart_3";
 	};
 
-    bt-dev{
-        compatible = "amlogic,bt-dev";
-        dev_name = "bt-dev";
-        status = "ok";
-        gpio_reset = "GPIOX_20";
-    };
-    wifi{
+	bt-dev {
+		compatible = "amlogic,bt-dev";
+		dev_name = "bt-dev";
+		status = "ok";
+		gpio_reset = "GPIOX_20";
+	};
+
+	wifi {
 		compatible = "amlogic,aml_broadcm_wifi";
 		dev_name = "aml_broadcm_wifi";
 		status = "okay";
@@ -256,135 +161,63 @@
 		power_on_pin2 = "GPIOX_11";
 		clock_32k_pin = "GPIOX_10";
 	};
-	
-	wifi_power{
-            compatible = "amlogic,wifi_power";
-            dev_name = "wifi_power";
-            status = "okay";
-            power_gpio = "GPIOAO_6";
-            power_gpio2 = "GPIOX_11";
-	}; 
 
-    sdio{
-        compatible = "amlogic,aml_sdio";
-        dev_name = "aml_sdio.0";
-        status = "okay";
-        reg = <0xc1108c20 0x20>;
-        pinctrl-names = "sd_clk_cmd_pins", "sd_all_pins", "emmc_clk_cmd_pins", "emmc_all_pins", "sdio_clk_cmd_pins", "sdio_all_pins","sd_1bit_pins"; // "jtag_pin", "uartao_default";
-        pinctrl-0 = <&sd_clk_cmd_pins>;
-        pinctrl-1 = <&sd_all_pins>;
-        pinctrl-2 = <&emmc_clk_cmd_pins>;
-        pinctrl-3 = <&emmc_all_pins>;
-        pinctrl-4 = <&sdio_clk_cmd_pins>;
-        pinctrl-5 = <&sdio_all_pins>;
-        pinctrl-6 = <&sd_1bit_pins>;
+	wifi_power {
+		compatible = "amlogic,wifi_power";
+		dev_name = "wifi_power";
+		status = "okay";
+		power_gpio = "GPIOAO_6";
+		power_gpio2 = "GPIOX_11";
+	};
 
-      sd{
-            status = "okay";
-            port = <1>;          /**0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-            pinname = "sd";
-            ocr_avail = <0x200000>;          /**VDD voltage 3.3 ~ 3.4 */
-            caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED";
-            f_min = <300000>;
-            f_max = <50000000>;
-            f_max_w = <50000000>;
-            max_req_size = <0x20000>;          /**128KB*/
-            gpio_dat3 = "CARD_4";
-            jtag_pin = "CARD_0";
-            gpio_cd = "CARD_6";
-//            gpio_ro = "GPIODV_25";
-            irq_in = <3>;
-            irq_out = <5>;
-            card_type = <5>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-        };
+	sdio {
+		compatible = "amlogic,aml_sdio";
+		dev_name = "aml_sdio.0";
+		status = "okay";
+		reg = <0xc1108c20 0x20>;
+		pinctrl-names = "sd_clk_cmd_pins", "sd_all_pins", "emmc_clk_cmd_pins", "emmc_all_pins", "sdio_clk_cmd_pins", "sdio_all_pins","sd_1bit_pins"; // "jtag_pin", "uartao_default";
+		pinctrl-0 = <&sd_clk_cmd_pins>;
+		pinctrl-1 = <&sd_all_pins>;
+		pinctrl-2 = <&emmc_clk_cmd_pins>;
+		pinctrl-3 = <&emmc_all_pins>;
+		pinctrl-4 = <&sdio_clk_cmd_pins>;
+		pinctrl-5 = <&sdio_all_pins>;
+		pinctrl-6 = <&sd_1bit_pins>;
 
-        emmc{
-            status = "ok";
-            port = <2>;          /**0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-            pinname = "emmc";
-            ocr_avail = <0x200000>;          /**VDD voltage 3.3 ~ 3.4 */
-            caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE","MMC_CAP_ERASE", "MMC_CAP_HW_RESET"; // MMC_CAP_NEEDS_POLL -- for detect, MMC_CAP_NONREMOVABLE -- for eMMC/TSD
-            f_min = <300000>;
-            f_max = <50000000>;
-            f_max_w = <50000000>;
-            max_req_size = <0x20000>;          /**128KB*/
-            gpio_dat3 = "BOOT_3";
-            card_type = <1>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-        };
+		sd {
+			status = "okay";
+			port = <1>; /* 0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
+			pinname = "sd";
+			ocr_avail = <0x200000>; /* VDD voltage 3.3 ~ 3.4 */
+			caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED";
+			f_min = <300000>;
+			f_max = <50000000>;
+			f_max_w = <50000000>;
+			max_req_size = <0x20000>;          /**128KB*/
+			gpio_dat3 = "CARD_4";
+			jtag_pin = "CARD_0";
+			gpio_cd = "CARD_6";
+			irq_in = <3>;
+			irq_out = <5>;
+			card_type = <5>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
+		};
 
-        sdio{
-            status = "ok";
-            port = <0>;          /*0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-            pinname = "sdio";
-            ocr_avail = <0x200000>;          /*VDD voltage 3.3 ~ 3.4 */
-            caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_SDIO_IRQ","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE";
-            f_min = <300000>;
-            f_max = <50000000>;
-            max_req_size = <0x20000>;          /**128KB*/
-            card_type = <3>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-        };
-    };
+		emmc {
+			status = "ok";
+			port = <2>; /* 0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
+			pinname = "emmc";
+			ocr_avail = <0x200000>; /* VDD voltage 3.3 ~ 3.4 */
+			caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE","MMC_CAP_ERASE", "MMC_CAP_HW_RESET";
+			f_min = <300000>;
+			f_max = <50000000>;
+			f_max_w = <50000000>;
+			max_req_size = <0x20000>; /* 128KB*/
+			gpio_dat3 = "BOOT_3";
+			card_type = <1>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
+		};
+	};
 
-//    sdhc{
-//        compatible = "amlogic,aml_sdhc";
-//        dev_name = "aml_sdhc.0";
-//        reg = <0xc1108e00 0x3c>;
-//        pinctrl-names = "sdhc_sd_clk_cmd_pins", "sdhc_sd_all_pins", "sdhc_emmc_clk_cmd_pins", "sdhc_emmc_all_pins", "sdhc_sdio_clk_cmd_pins", "sdhc_sdio_all_pins";
-//        pinctrl-0 = <&sdhc_sd_clk_cmd_pins>;
-//        pinctrl-1 = <&sdhc_sd_all_pins>;
-//        pinctrl-2 = <&sdhc_emmc_clk_cmd_pins>;
-//        pinctrl-3 = <&sdhc_emmc_all_pins>;
-//        pinctrl-4 = <&sdhc_sdio_clk_cmd_pins>;
-//        pinctrl-5 = <&sdhc_sdio_all_pins>;
-//        //pinctrl-6 = <&sd_1bit_pins>;
-
-//         sd{
-//             status = "okay";
-//             port = <4>;          /**0:sdhc_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-//             pinname = "sd";
-//             ocr_avail = <0x00200080>; // 3.3:0x200000, 1.8+3.3:0x00200080
-//             caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED","MMC_CAP_UHS_SDR12","MMC_CAP_UHS_SDR25","MMC_CAP_UHS_SDR50","MMC_CAP_UHS_SDR104";
-//             f_min = <300000>;
-//             f_max = <100000000>;
-//             max_req_size = <0x20000>;          /**128KB*/
-//             gpio_dat3 = "CARD_4";
-//             //jtag_pin = "CARD_0";
-//             gpio_cd = "CARD_6";
-//             //gpio_ro = "GPIOZ_0";
-//             irq_in = <3>;
-//             irq_out = <5>;
-//             card_type = <5>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-//         };
-
-//        emmc{
-//            status = "okay";
-//            port = <5>;          /**0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-//            pinname = "emmc";
-//            ocr_avail = <0x00200080>; // 3.3:0x200000, 1.8+3.3:0x00200080
-//            caps = "MMC_CAP_8_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE","MMC_CAP_ERASE", "MMC_CAP_HW_RESET"; // MMC_CAP_NEEDS_POLL -- for detect, MMC_CAP_NONREMOVABLE -- for eMMC/TSD
-//            caps2 = "MMC_CAP2_HS200_1_8V_SDR";
-//            f_min = <300000>;
-//            f_max = <100000000>;
-//            max_req_size = <0x20000>;          /**128KB*/
-//            gpio_dat3 = "BOOT_3";
-//            card_type = <1>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-//        };  
-
-        // sdio{
-        //     status = "okay";
-        //     port = <3>;          /**0:sdio_a, 1:sdio_b, 2:sdio_c, 3:sdhc_a, 4:sdhc_b, 5:sdhc_c */
-        //     pinname = "sdio";
-        //     ocr_avail = <0x00200080>; // 3.3:0x200000, 1.8+3.3:0x00200080
-        //     caps = "MMC_CAP_4_BIT_DATA","MMC_CAP_MMC_HIGHSPEED","MMC_CAP_SD_HIGHSPEED", "MMC_CAP_NONREMOVABLE", "MMC_CAP_UHS_SDR12","MMC_CAP_UHS_SDR25","MMC_CAP_UHS_SDR50","MMC_CAP_UHS_SDR104";
-        //     f_min = <300000>;
-        //     f_max = <100000000>;
-        //     max_req_size = <0x20000>;          /**128KB*/
-        //     card_type = <3>; /* 0:unknown, 1:mmc card(include eMMC), 2:sd card(include tSD), 3:sdio device(ie:sdio-wifi), 4:SD combo (IO+mem) card, 5:NON sdio device(means sd/mmc card), other:reserved */
-        // };
-//    };
-    
-
-	i2c@c8100500{ /*I2C-AO*/
+	i2c@c8100500{ /* I2C-AO */
 		compatible = "amlogic,aml_i2c";
 		dev_name = "i2c-AO";
 		status = "ok";
@@ -398,7 +231,7 @@
 		master_i2c_speed = <100000>;
 	};
 
-    i2c@c1108500{ /*I2C-A*/
+	i2c@c1108500 { /*I2C-A*/
 		compatible = "amlogic,aml_i2c";
 		dev_name = "i2c-A";
 		status = "ok";
@@ -411,8 +244,8 @@
 		use_pio = <0>;
 		master_i2c_speed = <300000>;
 	};
-	
-	i2c@c11087c0{ /*I2C-B*/
+
+	i2c@c11087c0 { /* I2C-B */
 		compatible = "amlogic,aml_i2c";
 		dev_name = "i2c-B";
 		status = "ok";
@@ -424,373 +257,281 @@
 		#size-cells = <0>;
 		use_pio = <0>;
 		master_i2c_speed = <300000>;
- 	};
+	};
 
-    i2c@c11087e0{ /*I2C-C*/
+	i2c@c11087e0 { /* I2C-C */
 		compatible = "amlogic,aml_i2c";
 		dev_name = "i2c-C";
 		status = "ok";
 		reg = <0xc11087e0 0x20>;
 		device_id = <3>;
 		pinctrl-names="default";
-//		pinctrl-0=<&c_i2c_master>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		use_pio = <0>;
 		master_i2c_speed = <300000>;
 	};
 
-	i2c@c1108d20{ /*I2C-D*/
+	i2c@c1108d20 { /* I2C-D */
 		compatible = "amlogic,aml_i2c";
 		dev_name = "i2c-D";
 		status = "ok";
 		reg = <0xc1108d20 0x20>;
 		device_id = <4>;
 		pinctrl-names="default";
-//		pinctrl-0=<&d_i2c_master>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		use_pio = <0>;
 		master_i2c_speed = <300000>;
 	};
 
-    dvfs {
-        compatible = "amlogic, amlogic-dvfs";                   /** fixed for driver, don't change       */
-        #address-cells = <1>;
-        #size-cells = <0>;
-        status = "ok";
+	dvfs {
+		compatible = "amlogic, amlogic-dvfs"; /* fixed for driver, don't change */
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "ok";
 
-        vcck_dvfs {
-            dvfs_id     = <1>;                                  /** must be value of (1 << n)            */
-            table_count = <12>;                                 /** must be correct count for dvfs_table */
-            dvfs_table  = <
-            /* NOTE: frequent in this table must be ascending order */
-            /* frequent(Khz)    min_uV      max_uV                  */
-                  96000         860000      860000
-                 192000         860000      860000
-                 312000         860000      860000
-                 408000         860000      860000
-                 504000         860000      860000
-                 600000         860000      860000
-                 720000         860000      860000
-                 816000         900000      900000
-                1008000         920000      920000
-                1200000         970000      970000
-                1320000        1050000     1050000
-                1488000        1100000     1100000
-            >;
-        };
-    };
-	meson_vcck_dvfs_driver{
-        compatible = "amlogic, meson_vcck_dvfs";
-        dev_name = "meson_vcck_dvfs_driver";
-        status = "ok";
-        pinctrl-names = "default";
-        pinctrl-0 = <&aml_pwm_pins>;
-        use_pwm = <1>; 
-        pmw_controller = "PWM_C";
-        table_count = <29>;
-        cs_voltage_table = <
-        /*   
-         * Note: This table is hardware depended, If your hardware use PWM method,
-         * then first line in this table is PWM register value, second line is
-         * voltage of VCCK according this PWM register value. If your platform use
-         * constant-current source to adjust vcck voltage, then the first line should 
-         * set to 0, means not valid, member 'use_pwm' in this node should set to 0.
-         *
-         *  ---- This table must be in ascending order by voltage ----
-         *    
-         *  PWM value       VCCK voltage 
-         */ 
-		0x1c0000        860000
-		0x1b0001        870000
-		0x1a0002        880000
-		0x190003        890000		
-		0x180004        900000			
-		0x170005        910000
-		0x160006        920000
-		0x150007        930000
-		0x140008        940000			
-		0x130009        950000		
-		0x12000a        960000			
-		0x11000b        970000		
-		0x10000c        980000			
-		0x0f000d        990000			
-		0x0e000e        1000000			
-		0x0d000f        1010000		
-		0x0c0010        1020000			
-		0x0b0011        1030000			
-		0x0a0012        1040000			
-		0x090013        1050000
-		0x080014        1060000
-		0x070015        1070000			
-		0x060016        1080000
-		0x050017        1090000
-		0x040018        1100000
-		0x030019        1110000			
-		0x02001a        1120000			
-		0x01001b        1130000
-		0x00001c        1140000
-        >;   
-    };   	
+		vcck_dvfs {
+			dvfs_id     = <1>; /* must be value of (1 << n) */
+			table_count = <12>; /* must be correct count for dvfs_table */
+			dvfs_table  = <
+			/* NOTE: frequent in this table must be ascending order */
+			/* frequent(Khz)    min_uV      max_uV                  */
+			      96000         860000      860000
+			     192000         860000      860000
+			     312000         860000      860000
+			     408000         860000      860000
+			     504000         860000      860000
+			     600000         860000      860000
+			     720000         860000      860000
+			     816000         900000      900000
+			    1008000         920000      920000
+			    1200000         970000      970000
+			    1320000        1050000     1050000
+			    1488000        1100000     1100000
+			>;
+		};
+ 	};
 
-    arm_pmu {
-        compatible = "arm,cortex-a9-pmu";
-        status = "ok";
-        interrupts = <0     137     0x04
-                      0     138     0x04
-                      0     153     0x04
-                      0     154     0x04>;
-    };
+	meson_vcck_dvfs_driver	{
+		compatible = "amlogic, meson_vcck_dvfs";
+		dev_name = "meson_vcck_dvfs_driver";
+		status = "ok";
+		pinctrl-names = "default";
+		pinctrl-0 = <&aml_pwm_pins>;
+		use_pwm = <1>;
+		pmw_controller = "PWM_C";
+		table_count = <29>;
+		cs_voltage_table = <
+			/*
+			 * Note: This table is hardware depended, If your hardware use PWM method,
+			 * then first line in this table is PWM register value, second line is
+			 * voltage of VCCK according this PWM register value. If your platform use
+			 * constant-current source to adjust vcck voltage, then the first line should
+			 * set to 0, means not valid, member 'use_pwm' in this node should set to 0.
+			 *
+			 *  ---- This table must be in ascending order by voltage ----
+			 *
+			 *  PWM value       VCCK voltage
+			 */
+			0x1c0000        860000
+			0x1b0001        870000
+			0x1a0002        880000
+			0x190003        890000
+			0x180004        900000
+			0x170005        910000
+			0x160006        920000
+			0x150007        930000
+			0x140008        940000
+			0x130009        950000
+			0x12000a        960000
+			0x11000b        970000
+			0x10000c        980000
+			0x0f000d        990000
+			0x0e000e        1000000
+			0x0d000f        1010000
+			0x0c0010        1020000
+			0x0b0011        1030000
+			0x0a0012        1040000
+			0x090013        1050000
+			0x080014        1060000
+			0x070015        1070000
+			0x060016        1080000
+			0x050017        1090000
+			0x040018        1100000
+			0x030019        1110000
+			0x02001a        1120000
+			0x01001b        1130000
+			0x00001c        1140000
+		>;
+	};
 
-    usb_con {
+	arm_pmu {
+		compatible = "arm,cortex-a9-pmu";
+		status = "ok";
+		interrupts = <0     137     0x04
+		              0     138     0x04
+		              0     153     0x04
+		              0     154     0x04>;
+	};
+
+	usb_con {
 		lm-compatible = "logicmodule-bus";
 
-		usb_b{
+		usb_b {
 			lm-compatible = "amlogic,usb";
-			lm-periph-id = <1>; /** lm name */
-			clock-src = "usb1"; /** clock src */
-			port-id = <1>; /** ref to mach/usb.h */
-			port-type = <1>;	/** 0: otg, 1: host, 2: slave */
-			port-speed = <0>; /** 0: default, 1: high, 2: full */
-			port-config = <0>; /** 0: default */
-			port-dma = <0>; /** 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
-			port-id-mode = <1>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
+			lm-periph-id = <1>; /* lm name */
+			clock-src = "usb1"; /* clock src */
+			port-id = <1>; /* ref to mach/usb.h */
+			port-type = <1>; /* 0: otg, 1: host, 2: slave */
+			port-speed = <0>; /* 0: default, 1: high, 2: full */
+			port-config = <0>; /* 0: default */
+			port-dma = <0>; /* 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
+			port-id-mode = <1>; /* 0: hardware, 1: sw_host, 2: sw_slave*/
 			status = "okay";
 		};
-		
-		usb_a{
+
+		usb_a {
 			lm-compatible = "amlogic,usb";
-			lm-periph-id = <0>; /** lm name */
-			clock-src = "usb0"; /** clock src */
-			port-id = <0>;  /** ref to mach/usb.h */
-			port-type = <1>;	/** 0: otg, 1: host, 2: slave */
-			port-speed = <0>; /** 0: default, high, 1: full */
-			port-config = <0>; /** 0: default */
-			port-dma = <0>; /** 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
-			port-id-mode = <0>; /** 0: hardware, 1: sw_host, 2: sw_slave*/
-//			gpio-vbus-power = "GPIOZ_1";
-			gpio-work-mask	= <1>; /**0: work on pulldown,1:work on pullup*/
+			lm-periph-id = <0>; /* lm name */
+			clock-src = "usb0"; /* clock src */
+			port-id = <0>; /* ref to mach/usb.h */
+			port-type = <1>; /* 0: otg, 1: host, 2: slave */
+			port-speed = <0>; /* 0: default, high, 1: full */
+			port-config = <0>; /* 0: default */
+			port-dma = <0>; /* 0: default, 1: single, 2: incr, 3: incr4, 4: incr8, 5: incr16, 6: disable*/
+			port-id-mode = <0>; /* 0: hardware, 1: sw_host, 2: sw_slave*/
+			gpio-work-mask	= <1>; /* 0: work on pulldown,1:work on pullup*/
 			status = "okay";
 		};
 	};
 
-
-
-
-    audio_platform{
-        compatible = "amlogic,aml-i2s";
-        dev_name = "aml-i2s.0";
-        status = "okay";
-    };
-
-    audio_dai{
-        compatible = "amlogic,aml-i2s-dai";
-        dev_name = "aml-i2s-dai.0";
-        status = "okay";
-    };
-    audio_spdif_dai{
-        compatible = "amlogic,aml-spdif-dai";
-        dev_name = "aml-spdif-dai.0";
-        status = "okay";
-    };
-
-    audio_spdif_codec{
-        compatible = "amlogic,aml-spdif-codec";
-        dev_name = "spdif-dit.0";
-        status = "okay";
-    };
-
-    audio_pcm2BT_codec{
-        compatible = "amlogic,pcm2BT-codec";
-        dev_name = "pcm2bt.0";
-        status = "okay";
-    };
-
-    audio_pcm_dai{
-        compatible = "amlogic,aml-pcm-dai";
-        dev_name = "aml-pcm-dai.0";
-        status = "okay";
-    };
-
-    audio_pcm{
-        compatible = "amlogic,aml-pcm";
-        dev_name = "aml-pcm.0";
-        status = "okay";
-    };
-
-    audio_m8_audio{
-        compatible = "amlogic,m8_audio_codec";
-        dev_name = "aml_m8_codec.0";
-        status = "disable";
-    };
-
-    dummy_codec{
-        compatible = "amlogic,aml_dummy_codec";
-        dev_name = "dummy_codec.0";
-        status = "okay";
-    };
-
-    aml_audio_codec{
-        compatible = "amlogic,audio_codec";
-        rt5616:rt5616{
-            codec_name = "rt5616";
-            i2c_addr = <0x1B>;
-            i2c_bus = "i2c_bus_d";
-            id_reg = <0x00>;
-            id_val = <0x21>;
-            capless = <0>;
-            status = "disable";
-        };
-        rt5631:rt5631{
-            codec_name = "rt5631";
-            i2c_addr = <0x1A>;
-            i2c_bus = "i2c_bus_b";
-            id_reg = <0x00>;
-            id_val = <0x01>;
-            capless = <0>;
-            status = "disable";      
-        };  
-        wm8960:wm8960{
-            codec_name = "wm8960";
-            i2c_addr = <0x1A>;
-            i2c_bus = "i2c_bus_b";
-            capless = <1>;
-            status = "disable";
-        };
-
-        dummy:dummy{
-          codec_name = "dummy_codec";
-          status = "okay";
-        };
-    };
-
-    aml_m8_sound_card{
-        compatible = "sound_card, aml_snd_m8";
-        aml,sound_card = "AML-M8AUDIO";
-        aml,codec_dai = "AML-M8","rt5616-aif1","rt5631-hifi","wm8960-hifi","dummy_codec";
-        //aml,codec_name = "aml_m8_codec.0","rt5616.4-001b";
-        //aml,audio-codec = <&rt5616>;
-        aml,audio-routing-rt5616 = 
-            "Ext Spk","LOUTL",
-            "Ext Spk","LOUTR",
-            "HP","HPOL",
-            "HP","HPOR",
-            "micbias1","MAIN MIC",
-            "IN2P","micbias1";
-        aml,audio-routing-amlm8 = 
-            "Ext Spk","LINEOUTL",
-            "Ext Spk","LINEOUTR",
-            "HP","HP_L",
-            "HP","HP_R",
-            "MICBIAS","MAIN MIC",
-            "LINPUT1","MICBIAS";
-        aml,audio-routing-dummy=
-            "Ext Spk","LOUTL",
-            "Ext Spk","LOUTR";
-        mute_gpio = "GPIO_BSD_EN";
-        hp_disable;
-        //mute_inv;
-        hp_paraments = <800 300 0 5 1>;
-        pinctrl-names = "aml_snd_m8";
-        pinctrl-0 = <&audio_pins>;
-        status = "okay";
-        
-    };
-
-	aml_cams{
-		compatible = "amlogic,cams_prober";
+	audio_platform {
+		compatible = "amlogic,aml-i2s";
+		dev_name = "aml-i2s.0";
 		status = "okay";
-		pinctrl-names = "gpio","csi";
-		pinctrl-0 = <&aml_cam_gpio_pins> ;
-		pinctrl-1 = <&aml_cam_csi_pins> ;
-
-		cam_0{
-			cam_name = "ar0543";
-			front_back = <0>;
-			i2c_bus = "i2c_bus_d";
-			gpio_pwdn = "GPIOH_6";
-			gpio_rst = "GPIOH_4";
-			mirror_flip = <0>;
-			vertical_flip = <0>;
-			config_path = "/system/etc/camera_isp_cfg/ar0543_skt";
-			mclk = <12000>;
-			bt_path = "csi";
-			interface = "mipi";
-			clk_channel = "a";
-			status = "okay";
-		};
-
-		cam_1{
-			cam_name = "ov5647";
-			front_back = <0>;
-			i2c_bus = "i2c_bus_d";
-			gpio_pwdn = "GPIOH_5";
-			gpio_rst = "GPIOH_4";
-			mirror_flip = <0>;
-			vertical_flip = <0>;	
-			config_path = "/system/etc/camera_isp_cfg/ov5647_cw0767";
-			bt_path = "csi";
-			interface = "mipi";
-			clk_channel = "b";
-			status = "okay";
-		};
-		
-		cam_2{
-			cam_name = "ar0833";
-			front_back = <0>;
-			i2c_bus = "i2c_bus_d";
-			gpio_pwdn = "GPIOH_6";
-			gpio_rst = "GPIOH_4";
-			mirror_flip = <0>;
-			vertical_flip = <0>;
-			config_path = "/system/etc/camera_isp_cfg/ar0833_skt";
-			mclk = <12000>;
-			bt_path = "csi";
-			interface = "mipi";
-			clk_channel = "a";
-			status = "okay";
-		};
-	};	
-
-    gpio_keypad{
-		compatible = "amlogic,gpio_keypad";
-		status = "okay";
-		scan_period = <20>;
-		key_num = <1>;
-        key_name = "power";
-		key_code = <116>;
-		key_pin = "GPIOAO_3";
-        irq_keyup = <6>;
-        irq_keydown = <7>;
 	};
-	saradc{
+
+	audio_dai {
+		compatible = "amlogic,aml-i2s-dai";
+		dev_name = "aml-i2s-dai.0";
+		status = "okay";
+	};
+
+	audio_spdif_dai {
+		compatible = "amlogic,aml-spdif-dai";
+		dev_name = "aml-spdif-dai.0";
+		status = "okay";
+	};
+
+	audio_spdif_codec {
+		compatible = "amlogic,aml-spdif-codec";
+		dev_name = "spdif-dit.0";
+		status = "okay";
+	};
+
+	audio_pcm2BT_codec {
+		compatible = "amlogic,pcm2BT-codec";
+		dev_name = "pcm2bt.0";
+		status = "okay";
+	};
+
+	audio_pcm_dai {
+		compatible = "amlogic,aml-pcm-dai";
+		dev_name = "aml-pcm-dai.0";
+		status = "okay";
+	};
+
+	audio_pcm {
+		compatible = "amlogic,aml-pcm";
+		dev_name = "aml-pcm.0";
+		status = "okay";
+	};
+
+	audio_m8_audio {
+		compatible = "amlogic,m8_audio_codec";
+		dev_name = "aml_m8_codec.0";
+		status = "disable";
+	};
+
+	dummy_codec {
+		compatible = "amlogic,aml_dummy_codec";
+		dev_name = "dummy_codec.0";
+		status = "okay";
+	};
+
+	aml_audio_codec {
+		compatible = "amlogic,audio_codec";
+
+			rt5616:rt5616 {
+			codec_name = "rt5616";
+			i2c_addr = <0x1b>;
+			i2c_bus = "i2c_bus_d";
+			id_reg = <0x00>;
+			id_val = <0x21>;
+			capless = <0>;
+			status = "disable";
+		};
+
+		rt5631:rt5631 {
+			codec_name = "rt5631";
+			i2c_addr = <0x1a>;
+			i2c_bus = "i2c_bus_b";
+			id_reg = <0x00>;
+			id_val = <0x01>;
+			capless = <0>;
+			status = "disable";
+		};
+
+		wm8960:wm8960 {
+			codec_name = "wm8960";
+			i2c_addr = <0x1a>;
+			i2c_bus = "i2c_bus_b";
+			capless = <1>;
+			status = "disable";
+		};
+
+		dummy:dummy {
+			codec_name = "dummy_codec";
+			status = "okay";
+		};
+	};
+
+	aml_m8_sound_card {
+	        compatible = "sound_card, aml_snd_m8";
+	        aml,sound_card = "AML-M8AUDIO";
+	        aml,codec_dai = "AML-M8","rt5616-aif1","rt5631-hifi","wm8960-hifi","dummy_codec";
+	        aml,audio-routing-rt5616 =
+	            "Ext Spk","LOUTL",
+	            "Ext Spk","LOUTR",
+	            "HP","HPOL",
+	            "HP","HPOR",
+	            "micbias1","main mic",
+	            "IN2P","micbias1";
+	        aml,audio-routing-amlm8 =
+	            "Ext Spk","LINEOUTL",
+	            "Ext Spk","LINEOUTR",
+	            "HP","HP_L",
+	            "HP","HP_R",
+	            "MICBIAS","MAIN_MIC",
+	            "LINPUT1","MICBIAS";
+	        aml,audio-routing-dummy=
+	            "Ext Spk","LOUTL",
+	            "Ext Spk","LOUTR";
+	        mute_gpio = "GPIO_BSD_EN";
+	        hp_disable;
+	        hp_paraments = <800 300 0 5 1>;
+	        pinctrl-names = "aml_snd_m8";
+	        pinctrl-0 = <&audio_pins>;
+	        status = "okay";
+	};
+
+	saradc {
 		compatible = "amlogic,saradc";
 		status = "okay";
 	};
 
-/*    adc_keypad{
-		compatible = "amlogic,adc_keypad";
-		status = "okay";
-		key_name = "menu", "vol-","vol+", "esc", "home";
-		key_num = <5>;
-		key_code = <139 114 115 1 102>;
-		key_chan = <0 0 0 0 0>;
-		key_val = <0 143 271 393 468>; //voltage=0/252/478/692/824mV, val=voltage/1800mV*1023
-		key_tolerance = <40 40 40 40 40>;
-	};
-*/
-
-    meson-remote{
-		compatible = "amlogic,aml_remote";
-		dev_name = "meson-remote";
-		status = "ok";
-		ao_baseaddr = <0xf3100480>;
-		pinctrl-names="default";
-		pinctrl-0=<&remote_pins>;
-	};
-
-    spi@cc000000{
+	spi@cc000000 {
 		compatible = "amlogic,apollo_spi_nor";
 		status = "ok";
 		reg = <0xcc000000 0x04000000>;
@@ -801,20 +542,20 @@
 		nr-part-0 = <&bootloader>;
 		nr-part-1 = <&ubootenv>;
 
-		bootloader:bootloader{
+		bootloader:bootloader {
 			name = "bootloader";
 			offset = <0>;
 			size = <0x100000>;
 		};
 
-		ubootenv:ubootenv{
+		ubootenv:ubootenv {
 			name = "ubootenv";
-		      offset = <0x100000>;
-		      size = <0x10000>;
+			offset = <0x100000>;
+			size = <0x10000>;
 		};
 	};
-	
-	nand{
+
+	nand {
 		compatible = "amlogic,aml_nand";
 		dev_name = "nand";
 		status = "ok";
@@ -833,7 +574,7 @@
 		};
 	};
 
-    efuse{
+	efuse {
 		compatible = "amlogic,efuse";
 		dev_name = "efuse";
 		status = "okay";
@@ -842,415 +583,344 @@
 		usid-min = <8>; /*reserved*/
 		usid-max = <31>; /*reserved*/
 	};
-	
-	thermal{
+
+	thermal {
 		compatible = "amlogic-thermal";
-		#thermal-cells=<7>;
+		#thermal-cells = <7>;
 		dev_name = "aml_thermal";
-        trip_point=<70 1488001 1488001 511 511 3 2
-                    80 1200001 1200001 435 435 2 2
-                    90  800001  800001 328 328 1 1
-                    110 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
-		cpu_cali_a=<0>;
-		idle_interval=<1000>;
-        use_virtual_thermal;
-        freq_sample_period=<30>;
-        report_time=<1 10 30 60>;         /* based on freq_sample_period */
-        cpu_virtual=<
-             500000  40  40  40  40
-             600000  45  55  60  65
-             800000  50  60  65  70
-            1000000  55  65  70  75
-            1200000  60  70  75  80
-            1350000  65  75  80  85
-        >;
-        gpu_virtual=<
-            183      40  40  40  40
-            251      40  45  50  55
-            319      50  60  65  70
-            426      55  65  70  75
-            511      60  70  75  80
-        >;
+		trip_point = <70 1488001 1488001 511 511 3 2
+		              80 1200001 1200001 435 435 2 2
+		              90  800001  800001 328 328 1 1
+		              110 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+		cpu_cali_a = <0>;
+		idle_interval = <1000>;
+		use_virtual_thermal;
+		freq_sample_period = <30>;
+		report_time = <1 10 30 60>; /* based on freq_sample_period */
+		cpu_virtual = <
+		     500000  40  40  40  40
+		     600000  45  55  60  65
+		     800000  50  60  65  70
+		    1000000  55  65  70  75
+		    1200000  60  70  75  80
+		    1350000  65  75  80  85
+		>;
+		gpu_virtual = <
+		    183      40  40  40  40
+		    251      40  45  50  55
+		    319      50  60  65  70
+		    426      55  65  70  75
+		    511      60  70  75  80
+		>;
 	};
-	
-    securitykey{
+
+	securitykey {
 		compatible = "amlogic,aml_keys";
 		status = "ok";
 	};
 
-    	unifykey{
-		compatible = "amlogic,unifykey";
-		status = "ok";
-
-		/*efuse-version = <20>;*/ /*m6 efuse version 2,m3 efuse version 1, not config efuse version in default*/
-		unifykey-num = <6>;
-		unifykey-index-0 = <&keysn_0>;
-		unifykey-index-1 = <&keysn_1>;
-		unifykey-index-2 = <&keysn_2>;
-		unifykey-index-3 = <&keysn_3>;
-		unifykey-index-4 = <&keysn_4>;
-		unifykey-index-5 = <&keysn_5>;
-
-
-		keysn_0: key_0{
-			key-name = "usid";
-			key-device = "nandkey";
-			key-dataformat = "allascii";
-			key-permit = "read","write","del";
-		};
-		
-		keysn_1:key_1{
-			key-name = "mac";
-			key-device = "nandkey";
-			key-dataformat = "hexdata";
-			key-permit = "read","write","del";
-		};
-		
-		keysn_2:key_2{
-			key-name = "hdcp";
-			key-device = "nandkey";
-			key-dataformat = "hexdata";
-			key-permit = "read","write","del";
-		};
-
-		keysn_3:key_3{
-			key-name = "secure_boot_set";
-			key-device = "efusekey";
-			key-dataformat = "hexdata";
-			key-permit = "read","write";
-		};
-		
-		keysn_4:key_4{
-			key-name = "mac_bt";
-			key-device = "nandkey";
-			key-dataformat = "hexdata";
-			key-permit = "read","write","del";
-		};
-		
-		keysn_5:key_5{
-			key-name = "mac_wifi";
-			key-device = "nandkey";
-			key-dataformat = "hexdata";
-			key-permit = "read","write","del";
-		};
-	};
-
-    amhdmitx{
+	amhdmitx {
 		compatible = "amlogic,amhdmitx";
 		dev_name = "amhdmitx";
 		status = "ok";
-        vend-data = <&vend_data>;
-        pwr-ctrl = <&pwr_ctrl>;
-        
-        vend_data: vend_data{
-            vendor_name = "Amlogic";           /* Max Chars: 8     */
-            vendor_id = <0x000000>;                 /* Refer to http://standards.ieee.org/develop/regauth/oui/oui.txt   */
-            product_desc = "M8 MBox SKTv1";        /* Max Chars: 16    */
-            cec_osd_string = "Amlogic MBox";        /* Max Chars: 14    */
-        };
-        
-        pwr_ctrl: pwr_ctrl{
-            pwr_5v_on = "";
-            pwr_5v_off = "";
-            pwr_3v3_on = "";
-            pwr_3v3_off = "";
-            pwr_hpll_vdd_on = "";
-            pwr_hpll_vdd_off = "";
-        };
+		vend-data = <&vend_data>;
+		pwr-ctrl = <&pwr_ctrl>;
+
+		vend_data: vend_data{
+			vendor_name = "Amlogic"; /* Max Chars: 8 */
+			vendor_id = <0x000000>; /* Refer to http://standards.ieee.org/develop/regauth/oui/oui.txt */
+			product_desc = "M8 MBox SKTv1"; /* Max Chars: 16 */
+			cec_osd_string = "Amlogic MBox"; /* Max Chars: 14 */
+		};
+
+		pwr_ctrl: pwr_ctrl{
+			pwr_5v_on = "";
+			pwr_5v_off = "";
+			pwr_3v3_on = "";
+			pwr_3v3_off = "";
+			pwr_hpll_vdd_on = "";
+			pwr_hpll_vdd_off = "";
+		};
 	};
 
-    aml_pm{
+	aml_pm {
 		compatible = "amlogic,pm-m8";
 		dev_name = "aml_pm_m8";
 		status = "okay";
 	};
 
-    cpufreq-meson{
-        compatible = "amlogic,cpufreq-meson";
-        status = "okay";
-    };
+	cpufreq-meson {
+		compatible = "amlogic,cpufreq-meson";
+		status = "okay";
+	};
 
-//    crypto_device{
-//       compatible = "amlogic,crypto-device";
-//       dev_name = "crypto_device";
-//    };
-
-	gpio:gpio{
+	gpio: gpio {
 		compatible = "amlogic,m8b-gpio";
 		dev_name = "gpio";
 		#gpio-cells=<2>;
 	};
 
-    pinmux{ 
+	pinmux {
 		compatible = "amlogic,pinmux-m8b";
 		dev_name = "pinmux";
-		#pinmux-cells=<2>;    
-    
-        ao_uart_pins:ao_uart{
-			amlogic,setmask=<10 0x1800>;
-			amlogic,pins="GPIOAO_0", "GPIOAO_1";
-		};
-		
-//		a_uart_pins:a_uart{
-//			amlogic,setmask=<4 0x3c00>;
-//			amlogic,pins="GPIOX_12", "GPIOX_13", "GPIOX_14", "GPIOX_15";
-//		};
+		#pinmux-cells=<2>;
 
-		b_uart_pins:b_uart{
-			amlogic,setmask=<4 0x03c0>;
-			amlogic,pins="GPIOX_16", "GPIOX_17", "GPIOX_18", "GPIOX_19";
+		ao_uart_pins: ao_uart {
+			amlogic,setmask = <10 0x1800>;
+			amlogic,pins = "GPIOAO_0", "GPIOAO_1";
 		};
-		
-		nand_input_state:nand_input{
-			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4",
-						"BOOT_5","BOOT_6","BOOT_7","BOOT_12","BOOT_13",
-						"BOOT_8","BOOT_9","BOOT_10","BOOT_11",
-						"BOOT_14","BOOT_15","BOOT_16","BOOT_17";
-			amlogic,enable-output=<1>;
+
+		b_uart_pins: b_uart {
+			amlogic,setmask = <4 0x03c0>;
+			amlogic,pins = "GPIOX_16", "GPIOX_17", "GPIOX_18", "GPIOX_19";
 		};
-		
-		conf_nand_state: conf_nand{
+
+		nand_input_state: nand_input {
 			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4",
-						"BOOT_5","BOOT_6","BOOT_7","BOOT_15";
+					"BOOT_5","BOOT_6","BOOT_7","BOOT_12","BOOT_13",
+					"BOOT_8","BOOT_9","BOOT_10","BOOT_11",
+					"BOOT_14","BOOT_15","BOOT_16","BOOT_17";
+			amlogic,enable-output = <1>;
+		};
+
+		conf_nand_state: conf_nand {
+			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4",
+					"BOOT_5","BOOT_6","BOOT_7","BOOT_15";
 			amlogic,pullup=<0>;
 		};
-		
-		nand_base: nand{
-			amlogic,setmask=<2 0x7fe0000>;
-			amlogic,clrmask=<	5 0xe
-							6 0x3f000000
-							4 0x7c000000>;
+
+		nand_base: nand {
+			amlogic,setmask = <2 0x7fe0000>;
+			amlogic,clrmask = <5 0xe
+					   6 0x3f000000
+					   4 0x7c000000>;
 			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4",
-						"BOOT_5","BOOT_6","BOOT_7","BOOT_8","BOOT_9",
-						"BOOT_10","BOOT_12","BOOT_13",
-						"BOOT_14","BOOT_15","BOOT_16","BOOT_17";
-		};
-		
-		sdhc_b_pins:sdhc_b_pin{
-			amlogic,setmask=<2 0xfc00>;
-			amlogic,clrmask=<2 0xf0 8 0x600>;
-			amlogic,pins="CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
+				       "BOOT_5","BOOT_6","BOOT_7","BOOT_8","BOOT_9",
+				       "BOOT_10","BOOT_12","BOOT_13",
+				       "BOOT_14","BOOT_15","BOOT_16","BOOT_17";
 		};
 
-		sdhc_c_pins:sdhc_c_pin{
-			amlogic,setmask=<6 0x3f000000>;
-			amlogic,clrmask=<4 0x6c000000 2 0x4c00000>;
-			amlogic,pins="BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_10","BOOT_11";
+		sdhc_b_pins: sdhc_b_pin {
+			amlogic,setmask = <2 0xfc00>;
+			amlogic,clrmask = <2 0xf0 8 0x600>;
+			amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
 		};
 
-		sdhc_a_pins:sdhc_a_pin{
-			amlogic,setmask=<8 0x3f>;
-			amlogic,clrmask=<5 0x6c00 >;
-			amlogic,pins="GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
+		sdhc_c_pins: sdhc_c_pin {
+			amlogic,setmask = <6 0x3f000000>;
+			amlogic,clrmask = <4 0x6c000000 2 0x4c00000>;
+			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_10","BOOT_11";
 		};
 
-        sdio_all_pins:sdio_all_pins{
-            amlogic,setmask=<8 0x0000003f>;         /*sdio a*/
-            amlogic,clrmask=<6 0x3f000000           /*sdio c*/
-                                2 0x0000fc00        /*sdio b*/
-                                5 0x00006c00>;      /*sdhc a*/
-            amlogic,pins = "GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        
-        sdio_clk_cmd_pins:sdio_clk_cmd_pins{
-            amlogic,setmask=<8 0x00000003>;         /*sdio a*/
-            amlogic,clrmask=<6 0x3f000000           /*sdio c*/
-                                2 0x0000fc00        /*sdio b*/
-                                5 0x00006c00>;      /*sdhc a*/
-            amlogic,pins = "GPIOX_8","GPIOX_9"; /** GPIOX_8:CLK, GPIOX_9:CMD */
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
+		sdhc_a_pins: sdhc_a_pin {
+			amlogic,setmask = <8 0x3f>;
+			amlogic,clrmask = <5 0x6c00 >;
+			amlogic,pins = "GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
+		};
 
-        sd_all_pins:sd_all_pins{
-            amlogic,setmask=<2 0x0000fc00>;         /*sdio b*/
-            amlogic,clrmask=<6 0x3f000000           /*sdio c*/
-                                8 0x0000063f        /*sdio a, UART*/
-                                2 0x000000f0>;      /*sdhc b*/
-            amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
-            amlogic,enable-output=<1>; /* 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        
-        sd_1bit_pins:sd_1bit_pins{
-            amlogic,setmask=<2 0x00008c00>;         /*sdio b*/
-            amlogic,clrmask=<6 0x3f000000           /*sdio c*/
-                                8 0x0000003f        /*sdio a*/
-                                2 0x000000f0>;      /*sdhc b*/
-            amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
-            amlogic,enable-output=<1>; /* 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        
-        sd_clk_cmd_pins:sd_clk_cmd_pins{
-            amlogic,setmask=<2 0x00000c00>;         /*sdio b*/
-            amlogic,clrmask=<6 0x3f000000           /*sdio c*/
-                                8 0x0000003f        /*sdio a*/
-                                2 0x000000f0>;      /*sdhc b*/
-            amlogic,pins = "CARD_2","CARD_3"; /** CARD_2:CLK, CARD_3:CMD */
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        
-        emmc_all_pins:emmc_all_pins{
-            amlogic,setmask=<6 0xfc000000>;         /*sdio c*/
-            amlogic,clrmask=<2 0x06c2fc00           /*sdio b & nand*/
-                                8 0x0000003f        /*sdio a*/
-                                4 0x6c000000>;        /*sdhc c*/
-            amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_8","BOOT_10";
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        
-        emmc_clk_cmd_pins:emmc_clk_cmd_pins{
-            amlogic,setmask=<6 0xc0000000>;         /*bit[30-31] */
-            amlogic,clrmask=<2 0x06c2fc00           /*sdio b & nand   nand bit17 bit25*/ 
-                                8 0x0000003f        /*sdio a*/
-                                7 0xc0000>;        /*sdhc c bit 18-19*/
-            amlogic,pins = "BOOT_8","BOOT_10"; /** BOOT_10:CMD, BOOT_8:CLK */
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-sdhc_sd_clk_cmd_pins:sdhc_sd_clk_cmd_pins{
-            amlogic,setmask=<2 0x00000030>;         /*sdhc b*/
-            amlogic,clrmask=<5 0x00007c00           /*sdhc a*/
-                                4 0x7c000000        /*sdhc c*/
-                                2 0x0000fc00        /*sdio b*/
-                                8 0x00000600>;      /*UART*/
-            amlogic,pins = "CARD_2","CARD_3"; /* CARD_2:CLK, CARD_3:CMD */
-            amlogic,enable-output=<1>; /* 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        sdhc_sd_all_pins:sdhc_sd_all_pins{
-            amlogic,setmask=<2 0x000000f0>;         /*sdhc b*/
-            amlogic,clrmask=<5 0x00007c00           /*sdhc a*/
-                                4 0x7c000000        /*sdhc c*/
-                                2 0x0000fc00        /*sdio b*/
-                                8 0x00000600>;      /*UART*/
-            amlogic,pins="CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
-            amlogic,enable-output=<1>; /* 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
+		sdio_all_pins: sdio_all_pins {
+			amlogic,setmask = <8 0x0000003f>;      /* sdio a */
+			amlogic,clrmask = <6 0x3f000000        /* sdio c */
+			                   2 0x0000fc00        /* sdio b */
+			                   5 0x00006c00>;      /* sdhc a */
+			amlogic,pins = "GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
 
-        sdhc_emmc_clk_cmd_pins:sdhc_emmc_clk_cmd_pins{
-            amlogic,setmask=<4 0x0c000000>;         /*bit[26-27] */
-            amlogic,clrmask=<2 0x04c000f0           /*sdhc b & nand*/
-                                5 0x00007c00        /*sdhc a*/
-                                6 0x3f000000>;        /*sdio c*/
-            amlogic,pins = "BOOT_16","BOOT_17"; /** BOOT_16:CMD, BOOT_17:CLK */
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        sdhc_emmc_all_pins:sdhc_emmc_all_pins{
-            amlogic,setmask=<4 0x7c000000>;         /*sdhc c*/
-            amlogic,clrmask=<2 0x04c000f0           /*sdhc b & nand*/
-                                5 0x00007c00        /*sdhc a*/
-                                6 0x3f000000>;        /*sdio c*/
-            amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4","BOOT_5","BOOT_6","BOOT_7","BOOT_16","BOOT_17";
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
+		sdio_clk_cmd_pins:sdio_clk_cmd_pins {
+			amlogic,setmask = <8 0x00000003>;      /* sdio a */
+			amlogic,clrmask = <6 0x3f000000        /* sdio c */
+			                   2 0x0000fc00        /* sdio b */
+			                   5 0x00006c00>;      /* sdhc a */
+			amlogic,pins = "GPIOX_8","GPIOX_9"; /* GPIOX_8:CLK, GPIOX_9:CMD */
+			amlogic,enable-output=<1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
 
-        sdhc_sdio_clk_cmd_pins:sdhc_sdio_clk_cmd_pins{
-            amlogic,setmask=<5 0x00000c00>;         /*sdhc a bit[10-11] */
-            amlogic,clrmask=<2 0x058000f0           /*sdhc b*/
-                                4 0x7c000000        /*sdhc c */
-                                8 0x0000003f>;        /*sdio a*/
-            amlogic,pins = "GPIOX_8","GPIOX_9"; /** BOOT_16:CMD, BOOT_17:CLK */
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
-        sdhc_sdio_all_pins:sdhc_sdio_all_pins{
-            amlogic,setmask=<5 0x00006c00>;         /*sdhc a*/
-            amlogic,clrmask=<2 0x058000f0           /*sdhc b*/
-                                4 0x7c000000        /*sdhc c */
-                                8 0x0000003f>;        /*sdio a*/
-            amlogic,pins = "GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
-            amlogic,enable-output=<1>; /** 0:output, 1:input */
-            amlogic,pullup=<1>;
-            amlogic,pullupen=<1>;
-        };
+		sd_all_pins: sd_all_pins {
+			amlogic,setmask = <2 0x0000fc00>;      /* sdio b */
+			amlogic,clrmask = <6 0x3f000000        /* sdio c */
+			                   8 0x0000063f        /* sdio a, UART */
+			                   2 0x000000f0>;      /* sdhc b */
+			amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
 
-        aml_cam_gpio_pins: aml_cam_gpio_pins{
-			amlogic,setmask=<3 0x80000
-					         9 0x37c>;
+		sd_1bit_pins: sd_1bit_pins {
+			amlogic,setmask = <2 0x00008c00>;      /* sdio b */
+			amlogic,clrmask = <6 0x3f000000        /* sdio c */
+			                   8 0x0000003f        /* sdio a */
+			                   2 0x000000f0>;      /* sdhc b */
+			amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sd_clk_cmd_pins: sd_clk_cmd_pins {
+			amlogic,setmask = <2 0x00000c00>;      /* sdio b */
+			amlogic,clrmask = <6 0x3f000000        /* sdio c */
+			                   8 0x0000003f        /* sdio a */
+			                   2 0x000000f0>;      /* sdhc b */
+			amlogic,pins = "CARD_2","CARD_3"; /* CARD_2:CLK, CARD_3:CMD */
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		emmc_all_pins: emmc_all_pins {
+			amlogic,setmask = <6 0xfc000000>;      /* sdio c */
+			amlogic,clrmask = <2 0x06c2fc00        /* sdio b & nand */
+			                   8 0x0000003f        /* sdio a */
+			                   4 0x6c000000>;      /* sdhc c */
+			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_8","BOOT_10";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		emmc_clk_cmd_pins: emmc_clk_cmd_pins {
+			amlogic,setmask = <6 0xc0000000>;     /* bit[30-31] */
+			amlogic,clrmask = <2 0x06c2fc00       /* sdio b & nand   nand bit17 bit25 */
+			                   8 0x0000003f       /* sdio a */
+			                   7 0xc0000>;        /* sdhc c bit 18-19 */
+			amlogic,pins = "BOOT_8","BOOT_10"; /** BOOT_10:CMD, BOOT_8:CLK */
+			amlogic,enable-output = <1>; /** 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sdhc_sd_clk_cmd_pins: sdhc_sd_clk_cmd_pins {
+			amlogic,setmask = <2 0x00000030>;        /* sdhc b */
+			amlogic,clrmask = <5 0x00007c00          /* sdhc a */
+			                   4 0x7c000000          /* sdhc c */
+			                   2 0x0000fc00          /* sdio b */
+			                   8 0x00000600>;        /* UART */
+			amlogic,pins = "CARD_2","CARD_3"; /* CARD_2:CLK, CARD_3:CMD */
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sdhc_sd_all_pins: sdhc_sd_all_pins {
+			amlogic,setmask = <2 0x000000f0>;      /* sdhc b */
+			amlogic,clrmask = <5 0x00007c00        /* sdhc a */
+			                   4 0x7c000000        /* sdhc c */
+			                   2 0x0000fc00        /* sdio b */
+			                   8 0x00000600>;      /* UART */
+			amlogic,pins = "CARD_0","CARD_1","CARD_2","CARD_3","CARD_4","CARD_5";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sdhc_emmc_clk_cmd_pins: sdhc_emmc_clk_cmd_pins {
+			amlogic,setmask = <4 0x0c000000>;      /* bit[26-27] */
+			amlogic,clrmask = <2 0x04c000f0        /* sdhc b & nand */
+			                   5 0x00007c00        /* sdhc a */
+			                   6 0x3f000000>;      /* sdio c */
+			amlogic,pins = "BOOT_16","BOOT_17"; /* BOOT_16:CMD, BOOT_17:CLK */
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+		sdhc_emmc_all_pins: sdhc_emmc_all_pins {
+			amlogic,setmask = <4 0x7c000000>;      /* sdhc c */
+			amlogic,clrmask = <2 0x04c000f0        /* sdhc b & nand */
+			                   5 0x00007c00        /* sdhc a */
+			                   6 0x3f000000>;      /* sdio c */
+			amlogic,pins = "BOOT_0","BOOT_1","BOOT_2","BOOT_3","BOOT_4","BOOT_5","BOOT_6","BOOT_7","BOOT_16","BOOT_17";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sdhc_sdio_clk_cmd_pins: sdhc_sdio_clk_cmd_pins {
+			amlogic,setmask = <5 0x00000c00>;      /* sdhc a bit[10-11] */
+			amlogic,clrmask = <2 0x058000f0        /* sdhc b */
+			                   4 0x7c000000        /* sdhc c */
+			                   8 0x0000003f>;      /* sdio a */
+			amlogic,pins = "GPIOX_8","GPIOX_9"; /* BOOT_16:CMD, BOOT_17:CLK */
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		sdhc_sdio_all_pins: sdhc_sdio_all_pins {
+			amlogic,setmask = <5 0x00006c00>;      /* sdhc a*/
+			amlogic,clrmask = <2 0x058000f0        /* sdhc b*/
+			                   4 0x7c000000        /* sdhc c*/
+			                   8 0x0000003f>;      /* sdio a*/
+			amlogic,pins = "GPIOX_0","GPIOX_1","GPIOX_2","GPIOX_3","GPIOX_8","GPIOX_9";
+			amlogic,enable-output = <1>; /* 0:output, 1:input */
+			amlogic,pullup = <1>;
+			amlogic,pullupen = <1>;
+		};
+
+		gpio_pins: aml_cam_gpio_pins {
+			amlogic,setmask = <3 0x80000
+					   9 0x37c>;
 			amlogic,pins = "GPIOH_9","GPIOY_6","GPIOY_7","GPIOY_8","GPIOY_9","GPIOY_10","GPIOY_11","GPIOY_12","GPIOY_13","GPIOY_14";
 		};
-		
+
 		aml_cam_csi_pins: aml_cam_csi_pins{
-			amlogic,setmask=<3 0x80000>;
+			amlogic,setmask = <3 0x80000>;
 			amlogic,pins = "GPIOH_9";
 		};
 
-		ao_i2c_master:ao_i2c{
-			amlogic,setmask=<10 0x60>;
-			amlogic,clrmask=<10 0x1800006>;
-			amlogic,pins="GPIOAO_4","GPIOAO_5";
+		ao_i2c_master: ao_i2c {
+			amlogic,setmask = <10 0x60>;
+			amlogic,clrmask = <10 0x1800006>;
+			amlogic,pins = "GPIOAO_4","GPIOAO_5";
 		};
 
-		a_i2c_master:a_i2c{
-			amlogic,setmask=<9 0xC0000000>;
-			amlogic,clrmask=<0 0x3C0300 
-			                 6 0xC00000
-			                 8 0x1800000>;
-			amlogic,pins="GPIODV_24","GPIODV_25";
+		a_i2c_master: a_i2c {
+			amlogic,setmask = <9 0xC0000000>;
+			amlogic,clrmask = <0 0x3C0300
+			                   6 0xC00000
+			                   8 0x1800000>;
+			amlogic,pins = "GPIODV_24","GPIODV_25";
 		};
 
-		b_i2c_master:b_i2c{
-			amlogic,setmask=<9 0x30000000>;
-			amlogic,clrmask=<0 0x480 
+		b_i2c_master: b_i2c {
+			amlogic,setmask = <9 0x30000000>;
+			amlogic,clrmask = <0 0x480
 			                 6 0x300000
 			                 8 0x10780000>;
-			amlogic,pins="GPIODV_26","GPIODV_27";
-		};
-		
-// MATCH "I2C_D_pin_match" = "&d_i2c_master"
-// L2 PROP_U32 2 = "amlogic,setmask"
-// L2 PROP_STR 2 = "amlogic,pins"
-//		d_i2c_master:d_i2c{
-//			amlogic,setmask=<4 0xc>;
-//			amlogic,pins="GPIOH_7","GPIOH_8";
-//		};
-
-        remote_pins:remote_pin{
-			amlogic,setmask=<10 0x1>;
-			amlogic,pins="GPIOAO_7";
+			amlogic,pins = "GPIODV_26","GPIODV_27";
 		};
 
-        audio_pins:audio_pin{
-            amlogic,setmask=<10 0x78000008>;
-            amlogic,clrmask=<10 0x80002000>;
-            amlogic,pins = "GPIOAO_8","GPIOAO_9","GPIOAO_10","GPIOAO_11","GPIOAO_13";
-        };
+		remote_pins: remote_pin {
+			amlogic,setmask = <10 0x1>;
+			amlogic,pins = "GPIOAO_7";
+		};
 
-		aml_spi_nor_pins: aml_spi_nor_pins{
-			amlogic,setmask=<5 0xf>;
-			amlogic,clrmask=<2 0x10380000>;
+		audio_pins: audio_pin {
+			amlogic,setmask = <10 0x78000008>;
+			amlogic,clrmask = <10 0x80002000>;
+			amlogic,pins = "GPIOAO_8","GPIOAO_9","GPIOAO_10","GPIOAO_11","GPIOAO_13";
+		};
+
+		aml_spi_nor_pins: aml_spi_nor_pins {
+			amlogic,setmask = <5 0xf>;
+			amlogic,clrmask = <2 0x10380000>;
 			amlogic,pins = "BOOT_11","BOOT_12","BOOT_13","BOOT_18";
 		};
-		aml_pwm_pins:aml_pwm{
-		    	amlogic,setmask=<3 0x1000000>;
-			amlogic,clrmask=<0 0x48
-					 7 0x10000020>;
-			amlogic,pins="GPIODV_9";
-		};
 
+		aml_pwm_pins: aml_pwm {
+			amlogic,setmask = <3 0x1000000>;
+			amlogic,clrmask = <0 0x48
+					   7 0x10000020>;
+			amlogic,pins = "GPIODV_9";
+		};
 	};
-    meson-eth{
+
+	meson-eth {
 		compatible = "amlogic,meson-eth";
 		dev_name = "meson-eth";
 		status = "okay";
@@ -1259,9 +929,8 @@ sdhc_sd_clk_cmd_pins:sdhc_sd_clk_cmd_pins{
 		new_maclogic = <1>;
 	};
 
-        mesondrm {
-                compatible = "amlogic,meson8b";
-                dev_name = "mesondrm";
-        };
-
+	mesondrm {
+		compatible = "amlogic,meson8b";
+		dev_name = "mesondrm";
+	};
 }; /* end of / */


### PR DESCRIPTION
This patch removes the eMMC sub-node. The MMC driver is unable to
manage both the SD card and the eMMC at the same time so when the eMMC
is actually present on the board the SD card speed is drastically
reduced.

Also we refactor/cleanup the DTS file.

[endlessm/eos-shell#5025]

Signed-off-by: Carlo Caione carlo@endlessm.com
