### PR TITLE
umplock: demote semaphore lock error to debug message

### DIFF
--- a/drivers/amlogic/gpu/umplock/umplock_driver.c
+++ b/drivers/amlogic/gpu/umplock/umplock_driver.c
@@ -226,7 +226,7 @@ static int do_umplock_process(_lock_cmd_priv *lock_cmd)
 			}
 		}
 
-		PERROR("failed lock, pid: %d, secure_id: 0x%x, ref_count: %d\n", lock_cmd->pid, lock_item->secure_id, device.items[i_index].references[ref_index].ref_count);
+		PDEBUG("failed lock, pid: %d, secure_id: 0x%x, ref_count: %d\n", lock_cmd->pid, lock_item->secure_id, device.items[i_index].references[ref_index].ref_count);
 
 		mutex_unlock(&device.item_list_lock);
 		return -ERESTARTSYS;


### PR DESCRIPTION
It's quite normal for down_interruptible() to be interrupted by a
signal, especially when working with Xorg and plenty of SIGIO/SIGALRM.
umplock already does the right thing by returning -ERESTARTSYS.
Demote this to a debug message.

[endlessm/eos-shell#4869]
