### PR TITLE
meson-vdec: align output buffer width to 8 bytes

### DIFF
--- a/drivers/media/platform/meson/image.c
+++ b/drivers/media/platform/meson/image.c
@@ -95,7 +95,8 @@ void dst_canvas_config(struct vframe_s *vf, struct vb2_buffer *buf)
 {
 	dma_addr_t phys_addr = vb2_dma_contig_plane_dma_addr(buf, 0);
 
-	canvas_config(DST_CANVAS_INDEX, phys_addr, vf->width * 4, vf->height,
+	canvas_config(DST_CANVAS_INDEX, phys_addr,
+		      round_up(vf->width, WIDTH_ALIGN) * 4, vf->height,
 		      CANVAS_ADDR_NOWRAP, CANVAS_BLKMODE_LINEAR);
 }
 

--- a/drivers/media/platform/meson/meson_vdec.h
+++ b/drivers/media/platform/meson/meson_vdec.h
@@ -18,6 +18,9 @@
 #include <media/v4l2-device.h>
 #include <media/v4l2-mem2mem.h>
 
+/* GE2D can only work with output buffers with an 8-byte aligned width */
+#define WIDTH_ALIGN 8
+
 struct vdec_dev {
 	struct v4l2_device	v4l2_dev;
 	struct vframe_receiver_s video_vf_receiver;


### PR DESCRIPTION
Testing with 480p.h264, video data was being decoded badly,
with a row stride problem evident.

Investigating further, it seems that GE2D can crop to any boundary,
but the output buffer must have an 8-byte-aligned width. Amlogic's
ionvideo aligns widths to 16 too.

Update the driver with this constraint, making use of V4L2's
bytesperline field, which allows us to specify padding on the right
of each line.

Improve the G_FMT/S_FMT/TRY_FMT sematics at the same time, now that
I understand it a little better.

[endlessm/eos-shell#5119]
