### PR TITLE
meson_hdmi: Correct a silly thinko from c73d17b

### DIFF
--- a/drivers/gpu/drm/meson/meson_hdmi.c
+++ b/drivers/gpu/drm/meson/meson_hdmi.c
@@ -186,7 +186,7 @@ static int fetch_edid(void)
 			break;
 	}
 
-	if (hdmi_rd_reg(TX_HDCP_ST_EDID_STATUS) & (1 << 4)) {
+	if (!(hdmi_rd_reg(TX_HDCP_ST_EDID_STATUS) & (1 << 4))) {
 		WARN(1, "Could not fetch EDID after 1 second\n");
 		return -1;
 	}


### PR DESCRIPTION
We should only warn and return an error if we _don't_ have any EDID data
after one second. I just got this check backwards.

[endlessm/eos-shell#5174]
