### PR TITLE
Revert "Disable sdhc node temporarily"

### DIFF
--- a/arch/arm/boot/dts/meson8b_m201_1G.dts
+++ b/arch/arm/boot/dts/meson8b_m201_1G.dts
@@ -215,7 +215,7 @@
 		};
 	};
 
-	/* sdhc {
+	sdhc {
 		compatible = "amlogic,aml_sdhc";
 		dev_name = "aml_sdhc.0";
 		status = "okay";
@@ -240,7 +240,7 @@
 			gpio_dat3 = "BOOT_3";
 			card_type = <0x1>;
 		};
-	}; */
+	};
 
 	i2c@c8100500{ /* I2C-AO */
 		compatible = "amlogic,aml_i2c";


### PR DESCRIPTION
This reverts commit 266c5be5f01719568d1cb4c1d6611f11955bce97.
Backporting the RCU changes from upstream seems to fix #5168 so we can
(hopefully) enable SDHC again.

endlessm/eos-shell#5168
