### PR TITLE
mm: Fix OOPS when swapping

### DIFF
--- a/mm/swap_state.c
+++ b/mm/swap_state.c
@@ -117,7 +117,7 @@ int __add_to_swap_cache(struct page *page, swp_entry_t entry)
 	return error;
 }
 
-#define COMPRESS_PREV_USE 1
+#define COMPRESS_PREV_USE 0
 int add_to_swap_cache(struct page *page, swp_entry_t entry, gfp_t gfp_mask)
 {
 	int error;


### PR DESCRIPTION
Compiling chromium with swapping enabled causes OOPS. This is caused by
an Amlogic patch to the swap management code. Avoid the codepath causing
the OOPS.

endlessm/eos-shell#5170
