### PR TITLE
v4l2/meson: Fix ENUM_FMT

### DIFF
--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -340,6 +340,9 @@ static int vidioc_enum_fmt_vid_cap(struct file *file, void *priv,
 	struct vdec_ctx *ctx = file2ctx(file);
 	v4l2_info(&ctx->dev->v4l2_dev, "enum_fmt_vid_cap\n");
 
+        if (f->index != 0)
+		return -EINVAL;
+
 	snprintf(f->description, sizeof(f->description), "ARGB");
 	f->pixelformat = V4L2_PIX_FMT_RGB32;
 	return 0;
@@ -350,6 +353,9 @@ static int vidioc_enum_fmt_vid_out(struct file *file, void *priv,
 {
 	struct vdec_ctx *ctx = file2ctx(file);
 	v4l2_info(&ctx->dev->v4l2_dev, "enum_fmt_vid_out\n");
+
+        if (f->index != 0)
+		return -EINVAL;
 
 	snprintf(f->description, sizeof(f->description), "H264");
 	f->pixelformat = V4L2_PIX_FMT_H264;


### PR DESCRIPTION
Currently the driver only implements one format, but ignores the index.
This makes the application loop infinitly since it expects to receive
EINVAL when the all the format has been enumerated.

Signed-off-by: Nicolas Dufresne nicolas.dufresne@collabora.com
