### PR TITLE
Fix v4l2/meson try_fmt and color format

### DIFF
--- a/drivers/media/platform/meson/image.c
+++ b/drivers/media/platform/meson/image.c
@@ -85,7 +85,7 @@ int vdec_process_image(struct vdec_dev *dev, struct vframe_s *vf,
 	int src_position[4];
 	int dst_paint_position[4];
 	int dst_plane_position[4];
-	int dst_pixel_format = GE2D_FORMAT_S32_ABGR; // FIXME allow fmt selection
+	int dst_pixel_format = GE2D_FORMAT_S32_ARGB; // FIXME allow fmt selection
 
 	v4l2_info(&dev->v4l2_dev, "Processing vf %d %p into vb2 buf %d\n",
 		  vf->index, vf, dst->v4l2_buf.index);

--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -343,8 +343,8 @@ static int vidioc_enum_fmt_vid_cap(struct file *file, void *priv,
         if (f->index != 0)
 		return -EINVAL;
 
-	snprintf(f->description, sizeof(f->description), "ARGB");
-	f->pixelformat = V4L2_PIX_FMT_RGB32;
+	snprintf(f->description, sizeof(f->description), "BGRA");
+	f->pixelformat = V4L2_PIX_FMT_BGR32;
 	return 0;
 }
 
@@ -385,7 +385,7 @@ static int vidioc_g_fmt_vid_cap(struct file *file, void *priv,
 
 	v4l2_info(&ctx->dev->v4l2_dev, "g_fmt_vid_cap\n");
 
-	mp->pixelformat = V4L2_PIX_FMT_RGB32;
+	mp->pixelformat = V4L2_PIX_FMT_BGR32;
 	mp->width = ctx->frame_width;
 	mp->height = ctx->frame_height;
 	mp->field = V4L2_FIELD_NONE;
@@ -414,7 +414,7 @@ static int vidioc_try_fmt_vid_cap(struct file *file, void *priv,
 	/* V4L2 specification suggests the driver corrects the format struct
 	 * if any of the dimensions is unsupported */
 	f->fmt.pix.field = field;
-	f->fmt.pix_mp.pixelformat = V4L2_PIX_FMT_RGB32;
+	f->fmt.pix_mp.pixelformat = V4L2_PIX_FMT_BGR32;
 	f->fmt.pix_mp.num_planes = 1;
 	plane->bytesperline = get_bytesperline(f->fmt.pix_mp.width);
 	plane->sizeimage = plane->bytesperline * f->fmt.pix_mp.height;


### PR DESCRIPTION
These two patches fixed minor issue with try_fmt and the color format. This at least makes GStreamer happy with the driver (except for EOS, and a race between sending header and reading output format, but that requires porting GST to the new APIs)
