### PR TITLE
meson-vdec: Timestamp passing and EOS handling

### DIFF
--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -35,9 +35,8 @@
 // FIXME tweak or make dynamic?
 #define VDEC_MAX_BUFFERS		32
 
-/* FIXME: does this need to be so big? an alternate/unused codepath in
- * amstream_probe() sets this to 3mb. */
-#define VDEC_ST_FIFO_SIZE	31719424
+/* This is used to store the encoded data */
+#define VDEC_ST_FIFO_SIZE	(3*1024*1024)
 
 /* FIXME: this is for the decoder, as a general buffer and also for the
  * decoded frame data. Maybe it doesn't have to be contiguous. */

--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -168,6 +168,7 @@ static void send_eos_tail(struct vdec_ctx *ctx)
 {
 	v4l2_info(&ctx->dev->v4l2_dev, "sending EOS tail to esparser\n");
 	ctx->eos_state = EOS_TAIL_SENT;
+	ctx->esparser_busy = true;
 	esparser_start_search(PARSER_VIDEO, ctx->eos_tail_buf_phys,
 			      EOS_TAIL_BUF_SIZE);
 }


### PR DESCRIPTION
This patchset add timestamp passingand legacy EOS handling with additional fixes. As both GST and Chromium uses the old way of triggering EOS, it is faster to add legacy support in the driver.
