### PR TITLE
drm/meson: Add error checking on drm_gem_cma_create_with_handle

### DIFF
--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -1205,6 +1205,8 @@ static int meson_ioctl_create_with_ump(struct drm_device *dev, void *data,
 	}
 
 	cma_obj = drm_gem_cma_create_with_handle(file, dev, size, &args->handle, &dma_attrs);
+	if (IS_ERR(cma_obj))
+		return PTR_ERR(cma_obj);
 
 	ump_mem.addr = cma_obj->paddr;
 	ump_mem.size = size;


### PR DESCRIPTION
[endlessm/eos-shell#5234]

Signed-off-by: Carlo Caione carlo@endlessm.com
