### PR TITLE
drm/meson: Fix ordering problem

### DIFF
--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -990,16 +990,10 @@ static int meson_vdec_open(struct file *file)
 	sbuf->buf_size = sbuf->default_buf_size = VDEC_ST_FIFO_SIZE;
 	sbuf->flag = BUF_FLAG_IOMEM;
 
-	ctx->image_thread = kthread_run(image_thread, ctx, DRIVER_NAME);
-	if (IS_ERR(ctx->image_thread)) {
-		ret = PTR_ERR(ctx->image_thread);
-		goto err_free_buf2;
-	}
-
 	ctx->m2m_ctx = v4l2_m2m_ctx_init(dev->m2m_dev, ctx, &queue_init);
 	if (IS_ERR(ctx->m2m_ctx)) {
 		ret = PTR_ERR(ctx->m2m_ctx);
-		goto err_stop_thread;
+		goto err_free_buf2;
 	}
 
 	v4l2_fh_add(&ctx->fh);
@@ -1017,6 +1011,12 @@ static int meson_vdec_open(struct file *file)
 	if (ret)
 		goto err_release_port;
 
+	ctx->image_thread = kthread_run(image_thread, ctx, DRIVER_NAME);
+	if (IS_ERR(ctx->image_thread)) {
+		ret = PTR_ERR(ctx->image_thread);
+		goto err_release_port;
+	}
+
 open_unlock:
 	mutex_unlock(&dev->dev_mutex);
 	return ret;
@@ -1024,9 +1024,6 @@ open_unlock:
 err_release_port:
 	amstream_port_release(amstream_find_port("amstream_vbuf"));
 	v4l2_fh_del(&ctx->fh);
-
-err_stop_thread:
-	kthread_stop(ctx->image_thread);
 
 err_free_buf2:
 	dma_free_coherent(NULL, EOS_TAIL_BUF_SIZE, ctx->eos_tail_buf,


### PR DESCRIPTION
[endlessm/eos-shell#5470]

Fix the Oops when the image_thread is immediately run before having the
possibility to create the m2m context.
