### PR TITLE
drm/meson: Make sure to unref gem obj's

### DIFF
--- a/drivers/gpu/drm/meson/meson_cache_control.c
+++ b/drivers/gpu/drm/meson/meson_cache_control.c
@@ -210,19 +210,12 @@ int meson_ioctl_set_domain(struct drm_device *dev, void *data, struct drm_file *
 	if (!dma_get_attr(DMA_ATTR_NON_CONSISTENT, &cma_obj->dma_attrs)) {
 		DBG_MSG(3, ("meson_ioctl_set_domain(): %02u Changing owner of uncached memory, cache flushing not needed.\n",
 			    args->handle));
+		cma_obj = ERR_PTR(-EINVAL);
 		goto out;
 	}
 
 	if (gem_obj->write_domain == args->write_domain) {
 		DBG_MSG(4, ("meson_ioctl_set_domain(): %02u New_user equal previous, cache flushing not needed\n",
-			    args->handle,));
-		goto out;
-	}
-	if (
-		/* Previous AND new is both different from CPU */
-		(gem_obj->write_domain != DRM_MESON_GEM_DOMAIN_CPU) && (args->write_domain != DRM_MESON_GEM_DOMAIN_CPU)
-	) {
-		DBG_MSG(4, ("meson_ioctl_set_domain(): %02u Previous and new user are not CPU, cache flushing not needed\n",
 			    args->handle,));
 		goto out;
 	}

--- a/drivers/gpu/drm/meson/meson_cache_control.c
+++ b/drivers/gpu/drm/meson/meson_cache_control.c
@@ -144,11 +144,6 @@ int meson_ioctl_msync(struct drm_device *dev, void *data, struct drm_file *file)
 	}
 
 	cma_obj = to_drm_gem_cma_obj(gem_obj);
-	if (NULL == cma_obj) {
-		DBG_MSG(1, ("meson_ioctl_msync(): %02u Failed to get gem_cma_obj containing gem_obj\n", args->handle));
-		return -EFAULT;
-	}
-
 	/* Returns the cache settings back to Userspace */
 	args->is_cached = dma_get_attr(DMA_ATTR_NON_CONSISTENT, &cma_obj->dma_attrs);
 
@@ -205,10 +200,6 @@ int meson_ioctl_set_domain(struct drm_device *dev, void *data, struct drm_file *
 	}
 
 	cma_obj = to_drm_gem_cma_obj(gem_obj);
-	if (NULL == cma_obj) {
-		DBG_MSG(1, ("meson_ioctl_set_domain(): %02u Failed to get gem_cma_obj containing gem_obj\n", args->handle));
-		return -EFAULT;
-	}
 
 	DBG_MSG(3, ("meson_ioctl_set_domain(): %02u %s -> %s\n",
 		    args->handle,


### PR DESCRIPTION
Otherwise, these will be leaked indefinitely.

[endlessm/eos-shell#5469]
