### PR TITLE
drm_prime: Don't bother flushing caches for mapping / unmapping bufs

### DIFF
--- a/drivers/gpu/drm/drm_prime.c
+++ b/drivers/gpu/drm/drm_prime.c
@@ -152,9 +152,14 @@ static void drm_gem_map_detach(struct dma_buf *dma_buf,
 
 	sgt = prime_attach->sgt;
 	if (sgt) {
-		if (prime_attach->dir != DMA_NONE)
-			dma_unmap_sg(attach->dev, sgt->sgl, sgt->nents,
-					prime_attach->dir);
+		if (prime_attach->dir != DMA_NONE) {
+			DEFINE_DMA_ATTRS(dma_attrs);
+
+			dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &dma_attrs);
+
+			dma_unmap_sg_attrs(attach->dev, sgt->sgl, sgt->nents,
+					   prime_attach->dir, &dma_attrs);
+		}
 		sg_free_table(sgt);
 	}
 
@@ -201,7 +206,11 @@ static struct sg_table *drm_gem_map_dma_buf(struct dma_buf_attachment *attach,
 	sgt = obj->dev->driver->gem_prime_get_sg_table(obj);
 
 	if (!IS_ERR(sgt)) {
-		if (!dma_map_sg(attach->dev, sgt->sgl, sgt->nents, dir)) {
+		DEFINE_DMA_ATTRS(dma_attrs);
+
+		dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &dma_attrs);
+
+		if (!dma_map_sg_attrs(attach->dev, sgt->sgl, sgt->nents, dir, &dma_attrs)) {
 			sg_free_table(sgt);
 			kfree(sgt);
 			sgt = ERR_PTR(-ENOMEM);


### PR DESCRIPTION
We'll mostly be using these bufs simply to share physical addresses
between the CPU and GPU, so we don't need flushing here.

[endlessm/eos-shell#5650]
