### PR TITLE
meson-vdec: support NV12 output format

### DIFF
--- a/drivers/media/platform/meson/meson_vdec.h
+++ b/drivers/media/platform/meson/meson_vdec.h
@@ -38,6 +38,7 @@ int vdec_image_init(struct vdec_dev *dev);
 void vdec_image_exit(struct vdec_dev *dev);
 
 int vdec_process_image(struct vdec_dev *dev, struct vframe_s *vf,
-		       struct vb2_buffer *dst, u32 bytesperline);
+		       struct vb2_buffer *dst, u32 pixelformat,
+		       unsigned int plane0size);
 
 #endif


### PR DESCRIPTION
Videos can now be decoded to NV12, if S_FMT is used to select this
format. This is used by Chromium and should result in lower memory
usage/bandwidth requirements than RGBA.

[endlessm/eos-shell#5625]
