### PR TITLE
sound/i2s: Do not expose MMAP operations

### DIFF
--- a/sound/soc/aml/m8/aml_i2s.c
+++ b/sound/soc/aml/m8/aml_i2s.c
@@ -103,8 +103,6 @@ static const struct snd_pcm_hardware aml_i2s_hardware = {
 static const struct snd_pcm_hardware aml_i2s_capture = {
 	.info			= SNDRV_PCM_INFO_INTERLEAVED|
 							SNDRV_PCM_INFO_BLOCK_TRANSFER|
-							SNDRV_PCM_INFO_MMAP |
-						 	SNDRV_PCM_INFO_MMAP_VALID |
 						  SNDRV_PCM_INFO_PAUSE,
 
 	.formats		= SNDRV_PCM_FMTBIT_S16_LE,


### PR DESCRIPTION
[endlessm/eos-shell#5715]

Signed-off-by: Carlo Caione carlo@endlessm.com
