### PR TITLE
USB/FIQ: Fix bad mode access when voluntary preemption is enabled

### DIFF
--- a/arch/arm/kernel/fiqasm.S
+++ b/arch/arm/kernel/fiqasm.S
@@ -54,3 +54,29 @@ ENDPROC(__get_fiq_regs)
 ENTRY(__FIQ_Branch)
 	mov pc, r8
 ENDPROC(__FIQ_Branch)
+
+/*
+ * There are two misteries not yet solved for this function:
+ *
+ *  - If we do not save R4 onto the stack end restore it before returning we
+ *    get an Oops in hcd_init() (we can as well use R5 instead of R4 without
+ *    saving onto the stack)
+ *
+ *  - This function is really not much different from '__set_fiq_regs()' but
+ *    using the latter we have the "Bad mode in data abort handler detected"
+ *    error also when setting the stack for each CPU.
+ */
+
+ENTRY(__fiq_ll_setup)
+	stmdb   sp!, {r4}
+	mrs	r4, cpsr
+@	and	r4, #~PSR_F_BIT
+	msr	cpsr_c, #(FIQ_MODE | PSR_I_BIT | PSR_F_BIT)
+	mov	r8, r0
+	mov	r9, r1
+	mov	fp, r2
+	mov	sp, r3
+	msr	cpsr_c, r4
+	ldmia sp!, {r4}
+	mov	pc, lr
+ENDPROC(__fiq_ll_setup)

--- a/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd.c
+++ b/drivers/amlogic/usb/dwc_otg/310/dwc_otg_hcd.c
@@ -1109,15 +1109,6 @@ int dwc_otg_hcd_init(dwc_otg_hcd_t * hcd, dwc_otg_core_if_t * core_if)
 		}
 		hcd->fiq_state->dummy_send = DWC_ALLOC_ATOMIC(16);
 
-		hcd->fiq_stack = DWC_ALLOC(sizeof(struct fiq_stack));
-		if (!hcd->fiq_stack) {
-			retval = -DWC_E_NO_MEMORY;
-			DWC_ERROR("%s: cannot allocate fiq_stack structure\n", __func__);
-			dwc_otg_hcd_free(hcd);
-			goto out;
-		}
-		hcd->fiq_stack->magic1 = 0xDEADBEEF;
-		hcd->fiq_stack->magic2 = 0xD00DFEED;
 		hcd->fiq_state->gintmsk_saved.d32 = ~0;
 		hcd->fiq_state->haintmsk_saved.b2.chint = ~0;
 


### PR DESCRIPTION
[endlessm/eos-shell#5907]
