### PR TITLE
Mesondrm cleanup

### DIFF
--- a/drivers/gpu/drm/meson/meson_cvbs.c
+++ b/drivers/gpu/drm/meson/meson_cvbs.c
@@ -216,8 +216,8 @@ static const struct drm_connector_helper_funcs meson_connector_helper_funcs = {
 	.best_encoder       = meson_connector_best_encoder,
 };
 
-struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
-						  struct drm_display_mode *mode)
+static struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
+							 struct drm_display_mode *mode)
 {
 	struct meson_connector *meson_connector;
 	struct drm_connector *connector;
@@ -275,6 +275,7 @@ static irqreturn_t cvbs_switch_intr_handler(int irq, void *user_data)
 
 int meson_cvbs_init(struct drm_device *dev)
 {
+	struct drm_display_mode *mode;
 	struct device *d = dev->dev;
 	const char *str;
 	int ret;
@@ -357,6 +358,16 @@ int meson_cvbs_init(struct drm_device *dev)
 		dev_warn(d, "Failed to claim cvbs_pal_gpio falling IRQ\n");
 		goto out;
 	}
+
+	mode = drm_cvt_mode(dev, CVBS_HACK_MODE_SIZE(720),
+			    CVBS_HACK_MODE_SIZE(480), 60, false, true, false);
+	mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	meson_cvbs_connector_create(dev, mode);
+
+	mode = drm_cvt_mode(dev, CVBS_HACK_MODE_SIZE(720),
+			    CVBS_HACK_MODE_SIZE(576), 50, false, true, false);
+	mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	meson_cvbs_connector_create(dev, mode);
 
 out:
 	return ret;

--- a/drivers/gpu/drm/meson/meson_cvbs.c
+++ b/drivers/gpu/drm/meson/meson_cvbs.c
@@ -131,7 +131,6 @@ fail:
 struct meson_connector {
 	struct drm_connector base;
 	struct drm_encoder *encoder;
-	bool enabled;
 	struct drm_display_mode *mode;
 };
 #define to_meson_connector(x) container_of(x, struct meson_connector, base)
@@ -164,9 +163,6 @@ static enum drm_connector_status meson_connector_detect(struct drm_connector *co
 	int vrefresh = drm_mode_vrefresh(meson_connector->mode);
 	enum meson_cvbs_switch_state s = meson_cvbs_get_switch_state();
 	struct device *d = connector->dev->dev;
-
-	if (!meson_connector->enabled)
-		return connector_status_disconnected;
 
 	/* PAL connector */
 	if (vrefresh == 100 && s != MESON_CVBS_SWITCH_PAL) {
@@ -221,7 +217,6 @@ static const struct drm_connector_helper_funcs meson_connector_helper_funcs = {
 };
 
 struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
-						  bool enabled,
 						  struct drm_display_mode *mode)
 {
 	struct meson_connector *meson_connector;
@@ -239,7 +234,6 @@ struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
 
 	connector = &meson_connector->base;
 	meson_connector->encoder = encoder;
-	meson_connector->enabled = enabled;
 	meson_connector->mode = mode;
 
 	drm_connector_init(dev, connector, &meson_connector_funcs, DRM_MODE_CONNECTOR_Composite);

--- a/drivers/gpu/drm/meson/meson_cvbs.h
+++ b/drivers/gpu/drm/meson/meson_cvbs.h
@@ -29,7 +29,6 @@
 #include <drm/drmP.h>
 
 struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
-                                                  bool enabled,
                                                   struct drm_display_mode *mode);
 int meson_cvbs_init(struct drm_device *dev);
 #endif

--- a/drivers/gpu/drm/meson/meson_cvbs.h
+++ b/drivers/gpu/drm/meson/meson_cvbs.h
@@ -28,7 +28,5 @@
 #include <linux/platform_device.h>
 #include <drm/drmP.h>
 
-struct drm_connector *meson_cvbs_connector_create(struct drm_device *dev,
-                                                  struct drm_display_mode *mode);
 int meson_cvbs_init(struct drm_device *dev);
 #endif

--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -898,24 +898,6 @@ static int meson_load(struct drm_device *dev, unsigned long flags)
 	meson_hdmi_connector_create(dev);
 	meson_cvbs_init(dev);
 
-	{
-		struct drm_display_mode *mode;
-
-		mode = drm_cvt_mode(dev, 720, 480, 60, false, true, false);
-		mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
-
-		meson_cvbs_connector_create(dev, mode);
-	}
-
-	{
-		struct drm_display_mode *mode;
-
-		mode = drm_cvt_mode(dev, 720, 576, 50, false, true, false);
-		mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
-
-		meson_cvbs_connector_create(dev, mode);
-	}
-
 	ret = drm_vblank_init(dev, dev->mode_config.num_crtc);
 	if (ret < 0) {
 		/* XXX: Don't leak memory. */

--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -50,14 +50,6 @@
 #include <linux/amlogic/hdmi_tx/hdmi_info_global.h>
 #include <linux/amlogic/hdmi_tx/hdmi_tx_module.h>
 
-enum meson_connectors {
-	MESON_CONNECTORS_HDMI      = 0x1,
-	MESON_CONNECTORS_CVBS_NTSC = 0x2,
-	MESON_CONNECTORS_CVBS_PAL  = 0x4,
-};
-static char enabled_connectors = 0;
-module_param(enabled_connectors, byte, S_IRUGO | S_IWUSR);
-
 #define DRIVER_NAME "meson"
 #define DRIVER_DESC "Amlogic Meson DRM driver"
 
@@ -903,13 +895,7 @@ static int meson_load(struct drm_device *dev, unsigned long flags)
 
 	priv->crtc = meson_crtc_create(dev);
 
-	if (enabled_connectors == 0)
-		/* Default: all enabled, CVBS mode selected via switch */
-		enabled_connectors = MESON_CONNECTORS_HDMI |
-				     MESON_CONNECTORS_CVBS_NTSC |
-				     MESON_CONNECTORS_CVBS_PAL;
-
-	meson_hdmi_connector_create(dev, !!(enabled_connectors & MESON_CONNECTORS_HDMI));
+	meson_hdmi_connector_create(dev);
 	meson_cvbs_init(dev);
 
 	{
@@ -918,7 +904,7 @@ static int meson_load(struct drm_device *dev, unsigned long flags)
 		mode = drm_cvt_mode(dev, 720, 480, 60, false, true, false);
 		mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
 
-		meson_cvbs_connector_create(dev, !!(enabled_connectors & MESON_CONNECTORS_CVBS_NTSC), mode);
+		meson_cvbs_connector_create(dev, mode);
 	}
 
 	{
@@ -927,7 +913,7 @@ static int meson_load(struct drm_device *dev, unsigned long flags)
 		mode = drm_cvt_mode(dev, 720, 576, 50, false, true, false);
 		mode->type |= DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
 
-		meson_cvbs_connector_create(dev, !!(enabled_connectors & MESON_CONNECTORS_CVBS_PAL), mode);
+		meson_cvbs_connector_create(dev, mode);
 	}
 
 	ret = drm_vblank_init(dev, dev->mode_config.num_crtc);

--- a/drivers/gpu/drm/meson/meson_hdmi.c
+++ b/drivers/gpu/drm/meson/meson_hdmi.c
@@ -145,7 +145,6 @@ struct meson_connector {
 	struct drm_connector base;
 	struct drm_encoder *encoder;
 	struct delayed_work hotplug_work;
-	bool enabled;
 };
 #define to_meson_connector(x) container_of(x, struct meson_connector, base)
 
@@ -163,10 +162,6 @@ static bool read_hpd_gpio(void)
 
 static enum drm_connector_status meson_connector_detect(struct drm_connector *connector, bool force)
 {
-	struct meson_connector *meson_connector = to_meson_connector(connector);
-	if (!meson_connector->enabled)
-		return connector_status_disconnected;
-
 	return read_hpd_gpio() ? connector_status_connected : connector_status_disconnected;
 }
 
@@ -297,8 +292,7 @@ static irqreturn_t meson_hdmi_intr_handler(int irq, void *user_data)
 	return IRQ_HANDLED;
 }
 
-struct drm_connector *meson_hdmi_connector_create(struct drm_device *dev,
-						  bool enabled)
+struct drm_connector *meson_hdmi_connector_create(struct drm_device *dev)
 {
 	struct meson_connector *meson_connector;
 	struct drm_connector *connector;
@@ -325,7 +319,6 @@ struct drm_connector *meson_hdmi_connector_create(struct drm_device *dev,
 
 	connector = &meson_connector->base;
 	meson_connector->encoder = encoder;
-	meson_connector->enabled = enabled;
 
 	drm_connector_init(dev, connector, &meson_connector_funcs, DRM_MODE_CONNECTOR_HDMIA);
 	drm_connector_helper_add(connector, &meson_connector_helper_funcs);

--- a/drivers/gpu/drm/meson/meson_hdmi.h
+++ b/drivers/gpu/drm/meson/meson_hdmi.h
@@ -28,7 +28,5 @@
 #include <linux/platform_device.h>
 #include <drm/drmP.h>
 
-struct drm_connector *meson_hdmi_connector_create(struct drm_device *dev,
-                                                  bool enabled);
-
+struct drm_connector *meson_hdmi_connector_create(struct drm_device *dev);
 #endif


### PR DESCRIPTION
This removes the `enabled_connectors` parameter, since it is not used anymore, and moves the CVBS connectors creation to `meson_cvbs_init()` in `meson_cvbs.c`.

@magcius Could you please review?
