### PR TITLE
UART: Switch to CLK81 clock when specified in the DTS

### DIFF
--- a/arch/arm/boot/dts/meson8b-ec100.dts
+++ b/arch/arm/boot/dts/meson8b-ec100.dts
@@ -133,6 +133,7 @@
 		dev_name = "uart_1";
 		pinctrl-names = "default";
 		pinctrl-0 = <&b_uart_pins>;
+		use_clk81;
 	};
 
 	uart_2 {


### PR DESCRIPTION
[endlessm/eos-shell#5960]
