### PR TITLE
meson-vdec: increase decoder src buffer size to 1mb

### DIFF
--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -798,8 +798,8 @@ static int vdec_src_queue_setup(struct vb2_queue *vq,
 
 	*nplanes = 1;
 
-	// FIXME is 512kb sensible?
-	sizes[0] = 512 * 1024;
+	// FIXME is 1mb sensible?
+	sizes[0] = 1024 * 1024;
 
 	alloc_ctxs[0] = ctx->dev->vb_alloc_ctx;
 


### PR DESCRIPTION
Occasionally, iframes in high bitrate videos would go over the
previous 512kb input buffer size, causing an error in userspace.

[endlessm/eos-shell#5955]
