### PR TITLE
meson-vdec: Return valid width/height in TRY_FMT

### DIFF
--- a/drivers/media/platform/meson/meson_drv.c
+++ b/drivers/media/platform/meson/meson_drv.c
@@ -187,8 +187,10 @@ static void configure_v4l2_plane_fmt(struct vdec_ctx *ctx,
 	struct buffer_size_info buf_info;
 
 	mp->pixelformat = ctx->fmt->pixelformat;
-	mp->width = ctx->frame_width;
-	mp->height = ctx->frame_height;
+	if (ctx->frame_width)
+		mp->width = ctx->frame_width;
+        if (ctx->frame_height)
+		mp->height = ctx->frame_height;
 	mp->field = V4L2_FIELD_NONE;
 
 	get_buffer_size_info(ctx->fmt, mp->width, mp->height, &buf_info);


### PR DESCRIPTION
When the driver is probed, before any H264 header has been passed,
TRY_FMT reset the width/height to 0. Application may be probing for
width/height acceptable range, which will result in a [0, 0], which
render the driver unusable generically.

https://github.com/endlessm/eos-shell/issues/5981
