### PR TITLE
Build with gcc-4.9

### DIFF
--- a/debian/config/defines
+++ b/debian/config/defines
@@ -4,7 +4,7 @@ abiname: trunk
 [base]
 arches:
  armhf
-compiler: gcc-4.7
+compiler: gcc-4.9
 featuresets:
  none
  rt
@@ -27,6 +27,7 @@ type: plain
 gcc-4.4: gcc-4.4
 gcc-4.6: gcc-4.6
 gcc-4.7: gcc-4.7
+gcc-4.9: gcc-4.9
 
 # initramfs-generators
 initramfs-fallback: linux-initramfs-tool

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian Kernel Team <debian-kernel@lists.debian.org>
 Uploaders: Bastian Blank <waldi@debian.org>, Frederik Schüler <fs@debian.org>, maximilian attems <maks@debian.org>, Ben Hutchings <ben@decadent.org.uk>
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>> 7), cpio, kmod | module-init-tools, python (>= 2.7), lzma [armel], kernel-wedge (>= 2.84), quilt, patchutils, bc, gcc-4.7 [armhf]
+Build-Depends: debhelper (>> 7), cpio, kmod | module-init-tools, python (>= 2.7), lzma [armel], kernel-wedge (>= 2.84), quilt, patchutils, bc, gcc-4.9 [armhf]
 Build-Depends-Indep: bzip2, xmlto
 Vcs-Svn: svn://svn.debian.org/svn/kernel/dists/trunk/linux/
 Vcs-Browser: http://anonscm.debian.org/viewvc/kernel/dists/trunk/linux/
@@ -64,7 +64,7 @@ Description: Linux 3.10 for Amlogic Meson8B
 Package: linux-headers-3.10-trunk-meson8b
 Architecture: armhf
 Provides: linux-headers
-Depends: linux-headers-3.10-trunk-common (= ${binary:Version}), linux-kbuild-3.10, ${misc:Depends}, gcc-4.7
+Depends: linux-headers-3.10-trunk-common (= ${binary:Version}), linux-kbuild-3.10, ${misc:Depends}, gcc-4.9
 Description: Header files for Linux 3.10-trunk-meson8b
  This package provides the architecture-specific kernel header files for
  Linux kernel 3.10-trunk-meson8b, generally used for building out-of-tree


### PR DESCRIPTION
gcc-4.7 got removed, so switch to using our current gcc-4.9.

[endlessm/eos-shell#6182]
