### PR TITLE
drm/meson: Use scattered allocation for non-scanout bo

### DIFF
--- a/drivers/gpu/drm/drm_gem_cma_helper.c
+++ b/drivers/gpu/drm/drm_gem_cma_helper.c
@@ -241,8 +241,8 @@ const struct vm_operations_struct drm_gem_cma_vm_ops = {
 };
 EXPORT_SYMBOL_GPL(drm_gem_cma_vm_ops);
 
-static int drm_gem_cma_mmap_obj(struct drm_gem_cma_object *cma_obj,
-				struct vm_area_struct *vma)
+int drm_gem_cma_mmap_obj(struct drm_gem_cma_object *cma_obj,
+			 struct vm_area_struct *vma)
 {
 	int ret;
 

--- a/drivers/gpu/drm/meson/Makefile
+++ b/drivers/gpu/drm/meson/Makefile
@@ -1,5 +1,5 @@
 ccflags-y := -Iinclude/drm
 
-meson-y := meson_drv.o meson_cvbs.o meson_hdmi.o meson_modes.o meson_cache_control.o
+meson-y := meson_drv.o meson_cvbs.o meson_hdmi.o meson_modes.o meson_cache_control.o meson_gem_prime.o
 
 obj-$(CONFIG_DRM_MESON) += meson.o

--- a/drivers/gpu/drm/meson/meson_cache_control.c
+++ b/drivers/gpu/drm/meson/meson_cache_control.c
@@ -26,6 +26,7 @@
 #include <linux/mutex.h>
 
 #include "meson_priv.h"
+#include "meson_gem_prime.h"
 
 #define DBG_MSG(level,args) do {} while(0) /* FIXME: debug properly */
 
@@ -35,16 +36,33 @@ static void level1_cache_flush_all(void)
 	__cpuc_flush_kern_all();
 }
 
+static void cache_control_op(enum drm_meson_msync_op op, u32 start_p, u32 end_p)
+{
+	switch (op) {
+	case DRM_MESON_MSYNC_CLEAN:
+		outer_clean_range(start_p, end_p);
+		break;
+	case DRM_MESON_MSYNC_CLEAN_AND_INVALIDATE:
+		outer_flush_range(start_p, end_p);
+		break;
+	case DRM_MESON_MSYNC_INVALIDATE:
+		outer_inv_range(start_p, end_p);
+		break;
+	default:
+		break;
+	}
+}
+
 /* This is a copy of _ump_osk_msync from drivers/amlogic/gpu/ump/linux/ump_osk_low_level_mem.c
  * with adapted parameters */
-static void meson_drm_ump_osk_msync(struct drm_gem_cma_object *cma_obj, void *virt, u32 offset, size_t size, enum drm_meson_msync_op op, struct meson_drm_session_data *session_data)
+static void meson_drm_ump_osk_msync(struct drm_gem_object *gem_obj, void *virt, u32 offset, size_t size, enum drm_meson_msync_op op, struct meson_drm_session_data *session_data)
 {
-	struct drm_gem_object *gem_obj;
 	u32 start_p, end_p;
+	int i;
 
 	/* Flush L1 using virtual address, the entire range in one go.
 	 * Only flush if user space process has a valid write mapping on given address. */
-	if ((cma_obj) && (virt != NULL) && (access_ok(VERIFY_WRITE, virt, size))) {
+	if ((gem_obj) && (virt != NULL) && (access_ok(VERIFY_WRITE, virt, size))) {
 		__cpuc_flush_dcache_area(virt, size);
 		DBG_MSG(3, ("meson_drm_ump_osk_msync(): Flushing CPU L1 Cache. CPU address: %x, size: %x\n", virt, size));
 	} else {
@@ -69,53 +87,54 @@ static void meson_drm_ump_osk_msync(struct drm_gem_cma_object *cma_obj, void *vi
 		}
 	}
 
-	if (!cma_obj)
+	if (!gem_obj)
 		return;
-	gem_obj = &cma_obj->base;
 
 	DBG_MSG(3, ("meson_drm_ump_osk_msync(): Flushing CPU L2 Cache\n"));
 
-	/* Flush L2 using physical addresses
-	 * Our allocations are always contiguous (GEM CMA), so we have only one mem block */
+	if (gem_obj->is_scattered) {
+		struct meson_drm_gem_scattered_object *meson_gem = to_meson_drm_gem_scattered_obj(gem_obj);
+		struct scatterlist *sgl;
+		int i;
 
-	if (offset >= gem_obj->size) {
-		offset -= gem_obj->size;
-		return;
-	}
+		for_each_sg(meson_gem->sgt->sgl, sgl, meson_gem->sgt->nents, i) {
+			start_p = sg_phys(sgl);
+			end_p = start_p + sgl->length;
 
-	if (offset) {
-		start_p = (u32)cma_obj->paddr + offset;
-		/* We'll zero the offset later, after using it to calculate end_p. */
-	} else {
-		start_p = (u32)cma_obj->paddr;
-	}
-
-	if (size < gem_obj->size - offset) {
-		end_p = start_p + size;
-		size = 0;
-	} else {
-		if (offset) {
-			end_p = start_p + (gem_obj->size - offset);
-			size -= gem_obj->size - offset;
-			offset = 0;
-		} else {
-			end_p = start_p + gem_obj->size;
-			size -= gem_obj->size;
+			cache_control_op(op, start_p, end_p);
 		}
-	}
+	} else {
+		struct drm_gem_cma_object *cma_obj = to_drm_gem_cma_obj(gem_obj);
+		/* Flush L2 using physical addresses
+		 * Our allocations are always contiguous (GEM CMA), so we have only one mem block */
 
-	switch (op) {
-	case DRM_MESON_MSYNC_CLEAN:
-		outer_clean_range(start_p, end_p);
-		break;
-	case DRM_MESON_MSYNC_CLEAN_AND_INVALIDATE:
-		outer_flush_range(start_p, end_p);
-		break;
-	case DRM_MESON_MSYNC_INVALIDATE:
-		outer_inv_range(start_p, end_p);
-		break;
-	default:
-		break;
+		if (offset >= gem_obj->size) {
+			offset -= gem_obj->size;
+			return;
+		}
+
+		if (offset) {
+			start_p = (u32)cma_obj->paddr + offset;
+			/* We'll zero the offset later, after using it to calculate end_p. */
+		} else {
+			start_p = (u32)cma_obj->paddr;
+		}
+
+		if (size < gem_obj->size - offset) {
+			end_p = start_p + size;
+			size = 0;
+		} else {
+			if (offset) {
+				end_p = start_p + (gem_obj->size - offset);
+				size -= gem_obj->size - offset;
+				offset = 0;
+			} else {
+				end_p = start_p + gem_obj->size;
+				size -= gem_obj->size;
+			}
+		}
+
+		cache_control_op(op, start_p, end_p);
 	}
 
 	return;
@@ -126,7 +145,8 @@ static void meson_drm_ump_osk_msync(struct drm_gem_cma_object *cma_obj, void *vi
 int meson_ioctl_msync(struct drm_device *dev, void *data, struct drm_file *file)
 {
 	struct drm_gem_object *gem_obj;
-	struct drm_gem_cma_object *cma_obj;
+	struct drm_gem_cma_object *cma_obj = NULL;
+	struct meson_drm_gem_scattered_object *gem_meson = NULL;
 	struct drm_meson_msync *args = data;
 	struct meson_drm_session_data *session_data = file->driver_priv;
 	int ret = 0;
@@ -144,10 +164,17 @@ int meson_ioctl_msync(struct drm_device *dev, void *data, struct drm_file *file)
 		return -EFAULT;
 	}
 
-	cma_obj = to_drm_gem_cma_obj(gem_obj);
+	if (gem_obj->is_scattered) {
+		gem_meson = to_meson_drm_gem_scattered_obj(gem_obj);
 
-	/* Returns the cache settings back to Userspace */
-	args->is_cached = dma_get_attr(DMA_ATTR_NON_CONSISTENT, &cma_obj->dma_attrs);
+		/* Returns the cache settings back to Userspace */
+		args->is_cached = dma_get_attr(DMA_ATTR_NON_CONSISTENT, &gem_meson->dma_attrs);
+	} else {
+		cma_obj = to_drm_gem_cma_obj(gem_obj);
+
+		/* Returns the cache settings back to Userspace */
+		args->is_cached = dma_get_attr(DMA_ATTR_NON_CONSISTENT, &cma_obj->dma_attrs);
+	}
 
 	DBG_MSG(3, ("meson_ioctl_msync(): %02u cache_enabled %d\n op %d address 0x%08x mapping 0x%08x\n",
 		    args->handle, args->is_cached, args->op, args->address, args->mapping));
@@ -178,7 +205,7 @@ int meson_ioctl_msync(struct drm_device *dev, void *data, struct drm_file *file)
 	}
 
 	/* No need to lock here since session_data=NULL */
-	meson_drm_ump_osk_msync(cma_obj, virtual, offset, gem_obj->size, args->op, NULL);
+	meson_drm_ump_osk_msync(gem_obj, virtual, offset, gem_obj->size, args->op, NULL);
 
  out:
 	drm_gem_object_unreference_unlocked(gem_obj);
@@ -190,10 +217,13 @@ int meson_ioctl_msync(struct drm_device *dev, void *data, struct drm_file *file)
 int meson_ioctl_set_domain(struct drm_device *dev, void *data, struct drm_file *file)
 {
 	struct drm_gem_object *gem_obj;
-	struct drm_gem_cma_object *cma_obj;
+	struct drm_gem_cma_object *cma_obj = NULL;
+	struct meson_drm_gem_scattered_object *gem_meson = NULL;
 	struct drm_meson_gem_set_domain *args = data;
 	struct meson_drm_session_data *session_data = file->driver_priv;
 	enum drm_meson_msync_op cache_op = DRM_MESON_MSYNC_CLEAN_AND_INVALIDATE;
+	struct dma_attrs *attrs;
+	int ret = 0;
 
 	if (!args || !session_data)
 		return -EINVAL;
@@ -204,18 +234,24 @@ int meson_ioctl_set_domain(struct drm_device *dev, void *data, struct drm_file *
 		return -EFAULT;
 	}
 
-	cma_obj = to_drm_gem_cma_obj(gem_obj);
-
 	DBG_MSG(3, ("meson_ioctl_set_domain(): %02u %s -> %s\n",
 		    args->handle,
 		    gem_obj->write_domain == DRM_MESON_GEM_DOMAIN_CPU ? "CPU" : "MALI",
 		    args->write_domain == DRM_MESON_GEM_DOMAIN_CPU ? "CPU" : "MALI"));
 
+	if (gem_obj->is_scattered) {
+		gem_meson = to_meson_drm_gem_scattered_obj(gem_obj);
+		attrs = &gem_meson->dma_attrs;
+	} else {
+		cma_obj = to_drm_gem_cma_obj(gem_obj);
+		attrs = &cma_obj->dma_attrs;
+	}
+
 	/* If the buffer is not cacheable there is no need to do anything */
-	if (!dma_get_attr(DMA_ATTR_NON_CONSISTENT, &cma_obj->dma_attrs)) {
+	if (!dma_get_attr(DMA_ATTR_NON_CONSISTENT, attrs)) {
 		DBG_MSG(3, ("meson_ioctl_set_domain(): %02u Changing owner of uncached memory, cache flushing not needed.\n",
 			    args->handle));
-		cma_obj = ERR_PTR(-EINVAL);
+		ret = -EINVAL;
 		goto out;
 	}
 
@@ -232,7 +268,7 @@ int meson_ioctl_set_domain(struct drm_device *dev, void *data, struct drm_file *
 		DBG_MSG(4, ("meson_ioctl_set_domain(): %02u Cache clean and invalidate\n", args->handle));
 
 	mutex_lock(&session_data->mutex);
-	meson_drm_ump_osk_msync(cma_obj, NULL, 0, gem_obj->size, cache_op, session_data);
+	meson_drm_ump_osk_msync(gem_obj, NULL, 0, gem_obj->size, cache_op, session_data);
 	mutex_unlock(&session_data->mutex);
 
 out:
@@ -242,7 +278,8 @@ out:
 	drm_gem_object_unreference_unlocked(gem_obj);
 
 	DBG_MSG(4, ("meson_ioctl_set_domain(): %02u Finish\n", args->handle));
-	return PTR_ERR_OR_ZERO(cma_obj);
+
+	return ret;
 }
 
 /* this code was heavily inspired by _ump_ukk_cache_operations_control() in

--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -39,6 +39,7 @@
 #include "meson_hdmi.h"
 #include "meson_modes.h"
 #include "meson_priv.h"
+#include "meson_gem_prime.h"
 
 #include <mach/am_regs.h>
 #include <mach/irqs.h>
@@ -1170,15 +1171,50 @@ static irqreturn_t meson_irq(int irq, void *arg)
 
 static void meson_gem_free_object(struct drm_gem_object *obj)
 {
-	drm_gem_cma_free_object(obj);
+	if (obj->is_scattered)
+		meson_drm_gem_scattered_free_object(obj);
+	else
+		drm_gem_cma_free_object(obj);
+}
+
+static struct sg_table *meson_gem_get_sg_table(struct drm_gem_object *obj)
+{
+	if (obj->is_scattered)
+		return meson_drm_gem_scattered_prime_get_sg_table(obj);
+	else
+		return drm_gem_cma_prime_get_sg_table(obj);
+}
+
+int meson_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	struct drm_gem_object *obj;
+	struct drm_gem_cma_object *cma_obj;
+	int ret;
+
+	ret = drm_gem_mmap(filp, vma);
+	if (ret)
+		return ret;
+
+	obj = vma->vm_private_data;
+
+	vma->vm_page_prot = vm_get_page_prot(vma->vm_flags);
+
+	if (!obj->is_scattered) {
+		cma_obj = to_drm_gem_cma_obj(obj);
+		return drm_gem_cma_mmap_obj(cma_obj, vma);
+	} else {
+		return meson_drm_gem_scattered_mmap_obj(obj, vma);
+	}
+
+	return 0;
 }
 
 static int meson_ioctl_create_with_ump(struct drm_device *dev, void *data,
 				       struct drm_file *file)
 {
 	struct drm_meson_gem_create_with_ump *args = data;
-	struct drm_gem_cma_object *cma_obj;
 	unsigned int size;
+	void *gem_obj;
 	DEFINE_DMA_ATTRS(dma_attrs);
 
 	/* UMP requires a page-aligned size for its buffers. */
@@ -1193,17 +1229,20 @@ static int meson_ioctl_create_with_ump(struct drm_device *dev, void *data,
 	if (args->flags & DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_SCANOUT) {
 		/* No caching for scanout buffers */
 		dma_set_attr(DMA_ATTR_WRITE_COMBINE, &dma_attrs);
+
+		gem_obj = drm_gem_cma_create_with_handle(file, dev, size, &args->handle, &dma_attrs);
 	} else {
 		/* Other buffers are textures and caches can be enabled. */
 		WARN_ON(!(args->flags & DRM_MESON_GEM_CREATE_WITH_UMP_FLAG_TEXTURE));
 		dma_set_attr(DMA_ATTR_NON_CONSISTENT, &dma_attrs);
+
+		gem_obj = meson_drm_gem_scattered_create_with_handle(dev, data, file, &dma_attrs);
 	}
 
-	cma_obj = drm_gem_cma_create_with_handle(file, dev, size, &args->handle, &dma_attrs);
-	if (IS_ERR(cma_obj))
-		return PTR_ERR(cma_obj);
+	if (IS_ERR(gem_obj))
+		return PTR_ERR(gem_obj);
 
-	return PTR_ERR_OR_ZERO(cma_obj);
+	return PTR_ERR_OR_ZERO(gem_obj);
 }
 
 static const struct drm_ioctl_desc meson_ioctls[] = {
@@ -1211,6 +1250,11 @@ static const struct drm_ioctl_desc meson_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(MESON_MSYNC, meson_ioctl_msync, DRM_UNLOCKED|DRM_AUTH|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(MESON_GEM_SET_DOMAIN, meson_ioctl_set_domain, DRM_UNLOCKED|DRM_AUTH|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(MESON_CACHE_OPERATIONS_CONTROL, meson_ioctl_cache_operations_control, DRM_UNLOCKED|DRM_AUTH|DRM_RENDER_ALLOW),
+};
+
+const struct vm_operations_struct meson_gem_vm_ops = {
+	.open = drm_gem_vm_open,
+	.close = drm_gem_vm_close,
 };
 
 #ifdef CONFIG_DEBUG_FS
@@ -1253,7 +1297,7 @@ static const struct file_operations fops = {
 	.poll               = drm_poll,
 	.read               = drm_read,
 	.llseek             = no_llseek,
-	.mmap               = drm_gem_cma_mmap,
+	.mmap               = meson_drm_gem_mmap,
 };
 
 static struct drm_driver meson_driver = {
@@ -1275,16 +1319,13 @@ static struct drm_driver meson_driver = {
 	.major              = 1,
 	.minor              = 0,
 	.gem_free_object    = meson_gem_free_object,
-	.gem_vm_ops         = &drm_gem_cma_vm_ops,
+	.gem_vm_ops         = &meson_gem_vm_ops,
 	.prime_handle_to_fd	= drm_gem_prime_handle_to_fd,
 	.prime_fd_to_handle	= drm_gem_prime_fd_to_handle,
 	.gem_prime_import	= drm_gem_prime_import,
 	.gem_prime_export	= drm_gem_prime_export,
-	.gem_prime_get_sg_table	= drm_gem_cma_prime_get_sg_table,
+	.gem_prime_get_sg_table	= meson_gem_get_sg_table,
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,
-	.gem_prime_vmap		= drm_gem_cma_prime_vmap,
-	.gem_prime_vunmap	= drm_gem_cma_prime_vunmap,
-	.gem_prime_mmap		= drm_gem_cma_prime_mmap,
 	.dumb_create        = drm_gem_cma_dumb_create,
 	.dumb_map_offset    = drm_gem_cma_dumb_map_offset,
 	.dumb_destroy       = drm_gem_dumb_destroy,

--- a/drivers/gpu/drm/meson/meson_gem_prime.c
+++ b/drivers/gpu/drm/meson/meson_gem_prime.c
@@ -1,0 +1,241 @@
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <linux/dma-buf.h>
+#include <linux/dma-mapping.h>
+
+#include <drm/drmP.h>
+#include <drm/drm.h>
+#include <drm/drm_gem_cma_helper.h>
+#include <drm/drm_vma_manager.h>
+
+#include <drm/meson_drm.h>
+
+#include "meson_priv.h"
+#include "meson_gem_prime.h"
+
+static struct meson_drm_gem_scattered_object *meson_drm_gem_init(
+		struct drm_device *dev,
+		unsigned long size)
+{
+	struct meson_drm_gem_scattered_object *scattered_obj;
+	struct drm_gem_object *obj;
+	int ret;
+
+	scattered_obj = kzalloc(sizeof(*scattered_obj), GFP_KERNEL);
+	if (!scattered_obj)
+		return ERR_PTR(-ENOMEM);
+
+	scattered_obj->size = size;
+	obj = &scattered_obj->base;
+
+	ret = drm_gem_object_init(dev, obj, size);
+	if (ret < 0) {
+		DRM_ERROR("failed to initialize gem object\n");
+		kfree(scattered_obj);
+		return ERR_PTR(ret);
+	}
+
+	ret = drm_gem_create_mmap_offset(obj);
+	if (ret < 0) {
+		drm_gem_object_release(obj);
+		kfree(scattered_obj);
+		return ERR_PTR(ret);
+	}
+
+	DRM_DEBUG_KMS("created file object = 0x%x\n", (unsigned int)obj->filp);
+
+	return scattered_obj;
+}
+
+static void meson_drm_gem_free(struct meson_drm_gem_scattered_object *scattered_obj,
+			       int page_count)
+{
+	while (page_count--)
+		if (scattered_obj->pages[page_count])
+			__free_pages(scattered_obj->pages[page_count], 0);
+	drm_free_large(scattered_obj->pages);
+}
+
+static int meson_drm_gem_alloc_buf(struct meson_drm_gem_scattered_object *scattered_obj)
+{
+	gfp_t gfp = GFP_KERNEL | GFP_DMA | __GFP_NOWARN | __GFP_NORETRY;
+	int count;
+	int ret = -ENOMEM;
+	int i = 0;
+
+	count = scattered_obj->size >> PAGE_SHIFT;
+
+	scattered_obj->pages = drm_calloc_large(count, sizeof(struct page *));
+	if (!scattered_obj->pages) {
+		DRM_ERROR("failed to allocate pages.\n");
+               return -ENOMEM;
+	}
+
+	while (count) {
+		int j, order = __fls(count);
+
+		scattered_obj->pages[i] = alloc_pages(gfp, order);
+		while (!scattered_obj->pages[i] && order)
+			scattered_obj->pages[i] = alloc_pages(gfp, --order);
+
+		if (!scattered_obj->pages[i])
+			goto error;
+
+		if (order) {
+			split_page(scattered_obj->pages[i], order);
+			j = 1 << order;
+			while (--j)
+				scattered_obj->pages[i + j] = scattered_obj->pages[i] + j;
+		}
+
+		i += 1 << order;
+		count -= 1 << order;
+	}
+
+	scattered_obj->nr_pages = i;
+
+	/* sgt for backend lowlevel buffer */
+	scattered_obj->sgt = drm_prime_pages_to_sg(scattered_obj->pages, scattered_obj->nr_pages);
+	if (IS_ERR(scattered_obj->sgt)) {
+		ret = PTR_ERR(scattered_obj->sgt);
+		goto error;
+	}
+
+	return 0;
+
+error:
+	meson_drm_gem_free(scattered_obj, i);
+	return ret;
+}
+
+static struct meson_drm_gem_scattered_object *meson_drm_gem_create(
+		struct drm_device *dev,
+		unsigned int flags,
+		unsigned long size)
+{
+	struct meson_drm_gem_scattered_object *scattered_obj;
+	int ret;
+
+	size = roundup(size, PAGE_SIZE);
+
+	scattered_obj = meson_drm_gem_init(dev, size);
+	if (IS_ERR(scattered_obj))
+		return scattered_obj;
+
+	scattered_obj->flags = flags;
+
+	ret = meson_drm_gem_alloc_buf(scattered_obj);
+	if (ret < 0) {
+		drm_gem_free_mmap_offset(&scattered_obj->base);
+		drm_gem_object_release(&scattered_obj->base);
+		kfree(scattered_obj);
+		return ERR_PTR(ret);
+	}
+
+	return scattered_obj;
+}
+
+void meson_drm_gem_destroy(struct meson_drm_gem_scattered_object *scattered_obj)
+{
+	struct drm_gem_object *obj = &scattered_obj->base;
+
+	drm_gem_free_mmap_offset(obj);
+
+	DRM_DEBUG_KMS("handle count = %d\n", obj->handle_count);
+
+	/*
+	 * TODO: we do not deal yet with dma_buf imported as a (scattered) gem object
+	 */
+	if (!obj->import_attach) {
+		meson_drm_gem_free(scattered_obj, scattered_obj->nr_pages);
+		sg_free_table(scattered_obj->sgt);
+		kfree(scattered_obj->sgt);
+	}
+
+	drm_gem_object_release(obj);
+
+	kfree(scattered_obj);
+}
+
+void meson_drm_gem_scattered_free_object(struct drm_gem_object *gem_obj)
+{
+	meson_drm_gem_destroy(to_meson_drm_gem_scattered_obj(gem_obj));
+}
+
+struct sg_table *meson_drm_gem_scattered_prime_get_sg_table(struct drm_gem_object *gem_obj)
+{
+	struct meson_drm_gem_scattered_object *scattered_obj;
+
+	scattered_obj = to_meson_drm_gem_scattered_obj(gem_obj);
+
+	/* the returned sgt will be deallocated by the buffer-user when detaching */
+	return drm_prime_pages_to_sg(scattered_obj->pages, scattered_obj->nr_pages);
+}
+
+static int meson_drm_gem_handle_create(struct drm_gem_object *obj,
+				       struct drm_file *file_priv,
+				       unsigned int *handle)
+{
+	int ret;
+
+	ret = drm_gem_handle_create(file_priv, obj, handle);
+	if (ret)
+		return ret;
+
+	DRM_DEBUG_KMS("gem handle = 0x%x\n", *handle);
+
+	drm_gem_object_unreference_unlocked(obj);
+
+	return 0;
+}
+
+struct meson_drm_gem_scattered_object *meson_drm_gem_scattered_create_with_handle(
+		struct drm_device *dev, void *data,
+		struct drm_file *file_priv,
+		struct dma_attrs *dma_attrs)
+{
+	struct drm_meson_gem_create_with_ump *args = data;
+	struct meson_drm_gem_scattered_object *scattered_obj;
+	int ret;
+
+	scattered_obj = meson_drm_gem_create(dev, args->flags, args->size);
+	if (IS_ERR(scattered_obj))
+		return scattered_obj;
+
+	scattered_obj->dma_attrs = *dma_attrs;
+	scattered_obj->base.is_scattered = true;
+
+	ret = meson_drm_gem_handle_create(&scattered_obj->base, file_priv,
+					  &args->handle);
+	if (ret) {
+		meson_drm_gem_destroy(scattered_obj);
+		return ERR_PTR(ret);
+	}
+
+	return scattered_obj;
+}
+
+int meson_drm_gem_scattered_mmap_obj(struct drm_gem_object *obj,
+				     struct vm_area_struct *vma)
+{
+	struct meson_drm_gem_scattered_object *meson_gem;
+	unsigned long addr = vma->vm_start;
+	int i, ret;
+
+	meson_gem = to_meson_drm_gem_scattered_obj(obj);
+
+	for (i = 0; i < meson_gem->nr_pages; i++) {
+		struct page *page = meson_gem->pages[i];
+
+		ret = vm_insert_pfn(vma, addr, page_to_pfn(page));
+		if (ret)
+			return -EFAULT;
+
+		addr += PAGE_SIZE;
+	}
+
+	return 0;
+}
+

--- a/drivers/gpu/drm/meson/meson_gem_prime.h
+++ b/drivers/gpu/drm/meson/meson_gem_prime.h
@@ -1,0 +1,35 @@
+#ifndef __MESON_GEM_PRIME_H__
+#define __MESON_GEM_PRIME_H__
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <drm/drmP.h>
+
+struct meson_drm_gem_scattered_object {
+	unsigned long size;
+	unsigned int flags;
+	unsigned int nr_pages;
+	struct drm_gem_object base;
+	struct page **pages;
+	struct dma_attrs dma_attrs;
+	struct sg_table *sgt;
+};
+
+static inline struct meson_drm_gem_scattered_object *
+to_meson_drm_gem_scattered_obj(struct drm_gem_object *gem_obj)
+{
+	return container_of(gem_obj, struct meson_drm_gem_scattered_object, base);
+}
+
+struct meson_drm_gem_scattered_object *meson_drm_gem_scattered_create_with_handle(
+		struct drm_device *dev, void *data,
+		struct drm_file *file_priv,
+		struct dma_attrs *dma_attrs);
+struct sg_table *meson_drm_gem_scattered_prime_get_sg_table(struct drm_gem_object *obj);
+void meson_drm_gem_scattered_free_object(struct drm_gem_object *gem_obj);
+int meson_drm_gem_scattered_mmap_obj(struct drm_gem_object *obj,
+				     struct vm_area_struct *vma);
+
+#endif

--- a/include/drm/drm_gem.h
+++ b/include/drm/drm_gem.h
@@ -119,6 +119,11 @@ struct drm_gem_object {
 	 * simply leave it as NULL.
 	 */
 	struct dma_buf_attachment *import_attach;
+
+	/*
+	 * is backed by scattered pages
+	 */
+	bool is_scattered;
 };
 
 void drm_gem_object_release(struct drm_gem_object *obj);

--- a/include/drm/drm_gem_cma_helper.h
+++ b/include/drm/drm_gem_cma_helper.h
@@ -36,6 +36,9 @@ int drm_gem_cma_dumb_map_offset(struct drm_file *file_priv,
 /* set vm_flags and we can change the vm attribute to other one at here. */
 int drm_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma);
 
+int drm_gem_cma_mmap_obj(struct drm_gem_cma_object *cma_obj,
+			 struct vm_area_struct *vma);
+
 /* allocate physical memory. */
 struct drm_gem_cma_object *drm_gem_cma_create(struct drm_device *drm,
 		unsigned int size);


### PR DESCRIPTION
[endlessm/eos-shell#6163]
