### PR TITLE
drm/meson: Use scattered allocation for non-scanout bo

### DIFF
--- a/drivers/gpu/drm/meson/Makefile
+++ b/drivers/gpu/drm/meson/Makefile
@@ -1,5 +1,5 @@
 ccflags-y := -Iinclude/drm
 
-meson-y := meson_drv.o meson_cvbs.o meson_hdmi.o meson_modes.o meson_cache_control.o
+meson-y := meson_drv.o meson_cvbs.o meson_hdmi.o meson_modes.o meson_cache_control.o meson_gem.o meson_fb.o
 
 obj-$(CONFIG_DRM_MESON) += meson.o

--- a/drivers/gpu/drm/meson/meson_fb.c
+++ b/drivers/gpu/drm/meson/meson_fb.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2016 Endless Mobile
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Carlo Caione <carlo@endlessm.com>
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <drm/drmP.h>
+#include <drm/drm_atomic.h>
+#include <drm/drm_atomic_helper.h>
+#include <drm/drm_flip_work.h>
+#include <drm/drm_crtc_helper.h>
+#include <drm/drm_gem_cma_helper.h>
+#include <drm/drm_plane_helper.h>
+#include <drm/drm_fb_helper.h>
+#include <drm/drm_rect.h>
+#include <drm/meson_drm.h>
+
+#include "meson_fb.h"
+#include "meson_cvbs.h"
+#include "meson_hdmi.h"
+#include "meson_modes.h"
+#include "meson_priv.h"
+#include "meson_gem.h"
+
+static void meson_fb_destroy(struct drm_framebuffer *fb)
+{
+	struct meson_framebuffer *mfb = drm_fb_to_meson_fb(fb);
+	int i;
+
+	for (i = 0; i < 4; i++)
+		if (mfb->obj[i])
+		drm_gem_object_unreference_unlocked(&mfb->obj[i]->base);
+
+	drm_framebuffer_cleanup(&mfb->fb);
+	kfree(mfb);
+}
+
+static int meson_fb_create_handle(struct drm_framebuffer *fb,
+				  struct drm_file *dfile,
+				  unsigned int *handle)
+{
+	struct meson_framebuffer *mfb = drm_fb_to_meson_fb(fb);
+
+	return drm_gem_handle_create(dfile, &mfb->obj[0]->base, handle);
+}
+
+static const struct drm_framebuffer_funcs meson_fb_funcs = {
+	.destroy	= meson_fb_destroy,
+	.create_handle	= meson_fb_create_handle,
+};
+
+static struct meson_framebuffer *meson_framebuffer_create(struct drm_device *dev,
+							  struct drm_mode_fb_cmd2 *mode,
+							  struct meson_drm_gem_object **obj,
+							  unsigned int num_planes)
+{
+	struct meson_framebuffer *mfb;
+	int ret;
+	int i;
+
+	mfb = kzalloc(sizeof(*mfb), GFP_KERNEL);
+	if (!mfb) {
+		DRM_ERROR("failed to allocate Meson fb object\n");
+		return ERR_PTR(-ENOMEM);
+	}
+
+	for (i = 0; i < num_planes; i++)
+		mfb->obj[i] = obj[i];
+
+	drm_helper_mode_fill_fb_struct(&mfb->fb, mode);
+
+	ret = drm_framebuffer_init(dev, &mfb->fb, &meson_fb_funcs);
+	if (ret) {
+		kfree(mfb);
+		return ERR_PTR(ret);
+	}
+
+	return mfb;
+}
+
+static struct fb_ops meson_fbdev_ops = {
+	.owner		= THIS_MODULE,
+	.fb_fillrect    = sys_fillrect,
+	.fb_copyarea    = sys_copyarea,
+	.fb_imageblit   = sys_imageblit,
+	.fb_check_var   = drm_fb_helper_check_var,
+	.fb_set_par     = drm_fb_helper_set_par,
+	.fb_blank       = drm_fb_helper_blank,
+	.fb_pan_display = drm_fb_helper_pan_display,
+	.fb_setcmap     = drm_fb_helper_setcmap,
+};
+
+static int meson_fbdev_create(struct drm_fb_helper *fbh,
+			      struct drm_fb_helper_surface_size *sizes)
+{
+	struct drm_device *dev = fbh->dev;
+	struct drm_mode_fb_cmd2 mode;
+	struct meson_drm_gem_object *obj;
+	struct fb_info *fbi;
+	struct meson_framebuffer *mfb;
+	struct drm_framebuffer *fb;
+	unsigned int bytes_per_pixel;
+	unsigned long offset;
+	size_t size;
+	int ret;
+
+	bytes_per_pixel = DIV_ROUND_UP(sizes->surface_bpp, 8);
+
+	memset(&mode, 0, sizeof(mode));
+	mode.width = sizes->surface_width;
+	mode.height = sizes->surface_height;
+	mode.pitches[0] = sizes->surface_width * bytes_per_pixel;
+	mode.pixel_format = drm_mode_legacy_fb_format(sizes->surface_bpp, sizes->surface_depth);
+
+	size = mode.pitches[0] * mode.height;
+	obj = meson_drm_gem_create_obj(dev, size);
+	if (!obj) {
+		DRM_ERROR("failed to allocate fb memory\n");
+		return -ENOMEM;
+	}
+
+	fbi = framebuffer_alloc(0, dev->dev);
+	if (!fbi) {
+		dev_err(dev->dev, "Failed to allocate framebuffer info.\n");
+		ret = -ENOMEM;
+		goto err_drm_gem_free_object;
+	}
+
+	mfb = meson_framebuffer_create(dev, &mode, &obj, 1);
+	if (IS_ERR(mfb)) {
+		dev_err(dev->dev, "Failed to allocate DRM framebuffer.\n");
+		ret = PTR_ERR(mfb);
+		goto err_framebuffer_release;
+	}
+
+	fb = &mfb->fb;
+	fbh->fb = fb;
+	fbh->fbdev = fbi;
+
+	fbi->par = fbh;
+	fbi->flags = FBINFO_FLAG_DEFAULT;
+	fbi->fbops = &meson_fbdev_ops;
+
+	ret = fb_alloc_cmap(&fbi->cmap, 256, 0);
+	if (ret) {
+		dev_err(dev->dev, "Failed to allocate color map.\n");
+		goto err_drm_fb_destroy;
+	}
+
+	drm_fb_helper_fill_fix(fbi, mfb->fb.pitches[0], mfb->fb.depth);
+	drm_fb_helper_fill_var(fbi, fbh, sizes->fb_width, sizes->fb_height);
+
+	offset = fbi->var.xoffset * bytes_per_pixel;
+	offset += fbi->var.yoffset * fb->pitches[0];
+
+	dev->mode_config.fb_base = (resource_size_t)obj->paddr;
+	fbi->screen_base = obj->vaddr + offset;
+	fbi->fix.smem_start = (unsigned long)(obj->paddr + offset);
+	fbi->screen_size = size;
+	fbi->fix.smem_len = size;
+
+	return 0;
+
+err_drm_fb_destroy:
+	drm_framebuffer_unregister_private(fb);
+	meson_fb_destroy(fb);
+err_framebuffer_release:
+	framebuffer_release(fbi);
+err_drm_gem_free_object:
+	meson_drm_gem_free_object(&obj->base);
+	return ret;
+}
+
+static int meson_fbdev_probe(struct drm_fb_helper *fbh,
+		struct drm_fb_helper_surface_size *sizes)
+{
+	int ret = 0;
+
+	if (!fbh->fb) {
+		ret = meson_fbdev_create(fbh, sizes);
+		if (ret == 0)
+			ret = 1;
+	}
+
+	return ret;
+}
+
+static const struct drm_fb_helper_funcs meson_fbdev_helper_funcs = {
+	.fb_probe = meson_fbdev_probe,
+};
+
+struct drm_fb_helper *meson_fbdev_init(struct drm_device *dev,
+				       unsigned int preferred_bpp,
+				       unsigned int num_crtc,
+				       unsigned int max_conn_count)
+{
+	struct drm_fb_helper *fbh;
+	int ret;
+
+	fbh = devm_kzalloc(dev->dev, sizeof(*fbh), GFP_KERNEL);
+	if (!fbh)
+		return ERR_PTR(-ENOMEM);
+
+	drm_fb_helper_prepare(dev, fbh, &meson_fbdev_helper_funcs);
+
+	ret = drm_fb_helper_init(dev, fbh, num_crtc, max_conn_count);
+	if (ret) {
+		DRM_ERROR("failed to initialize drm fb helper\n");
+		goto err_fb_helper;
+	}
+
+	ret = drm_fb_helper_single_add_all_connectors(fbh);
+	if (ret) {
+		DRM_ERROR("failed to add fb connectors\n");
+		goto err_fb_setup;
+	}
+
+	ret = drm_fb_helper_initial_config(fbh, preferred_bpp);
+	if (ret) {
+		DRM_ERROR("failed to set initial config\n");
+		goto err_fb_setup;
+	}
+
+	return fbh;
+
+err_fb_setup:
+	drm_fb_helper_fini(fbh);
+err_fb_helper:
+	return ERR_PTR(ret);
+}
+
+struct drm_framebuffer *meson_fb_create(struct drm_device *dev,
+					struct drm_file *file_priv,
+					struct drm_mode_fb_cmd2 *mode_cmd)
+{
+	struct drm_gem_object *obj;
+	struct meson_drm_gem_object *objs[4];
+	struct meson_framebuffer *mfb;
+	unsigned int hsub;
+	unsigned int vsub;
+	int ret;
+	int i;
+
+	hsub = drm_format_horz_chroma_subsampling(mode_cmd->pixel_format);
+	vsub = drm_format_vert_chroma_subsampling(mode_cmd->pixel_format);
+
+	for (i = 0; i < drm_format_num_planes(mode_cmd->pixel_format); i++) {
+		unsigned int width = mode_cmd->width / (i ? hsub : 1);
+		unsigned int height = mode_cmd->height / (i ? vsub : 1);
+		unsigned int min_size;
+
+		obj = drm_gem_object_lookup(dev, file_priv, mode_cmd->handles[i]);
+		if (!obj) {
+			dev_err(dev->dev, "Failed to lookup GEM object\n");
+			ret = -ENXIO;
+			goto err_gem_object_unreference;
+		}
+
+		min_size = (height - 1) * mode_cmd->pitches[i]
+			 + width * drm_format_plane_cpp(mode_cmd->pixel_format, i)
+			 + mode_cmd->offsets[i];
+
+		if (obj->size < min_size) {
+			drm_gem_object_unreference_unlocked(obj);
+			ret = -EINVAL;
+			goto err_gem_object_unreference;
+		}
+		objs[i] = to_meson_drm_gem_obj(obj);
+	}
+
+	mfb = meson_framebuffer_create(dev, mode_cmd, objs, i);
+	if (IS_ERR(mfb)) {
+		ret = PTR_ERR(mfb);
+		goto err_gem_object_unreference;
+	}
+
+	return &mfb->fb;
+
+err_gem_object_unreference:
+	for (i--; i >= 0; i--)
+		drm_gem_object_unreference_unlocked(&objs[i]->base);
+	return ERR_PTR(ret);
+}
+
+struct meson_drm_gem_object *meson_drm_get_gem_obj(struct drm_framebuffer *fb,
+						   unsigned int plane)
+{
+	struct meson_framebuffer *mfb = drm_fb_to_meson_fb(fb);
+
+	if (plane >= 4)
+		return NULL;
+
+	return mfb->obj[plane];
+}
+
+static void meson_drm_fb_describe(struct drm_framebuffer *fb, struct seq_file *m)
+{
+	struct meson_framebuffer *mfb = drm_fb_to_meson_fb(fb);
+	struct meson_drm_gem_object *meson_obj;
+	struct drm_gem_object *obj;
+	int i, n = drm_format_num_planes(fb->pixel_format);
+
+	seq_printf(m, "fb: %p %dx%d@%4.4s\n", fb, fb->width, fb->height,
+			(char *)&fb->pixel_format);
+
+	for (i = 0; i < n; i++) {
+		meson_obj = mfb->obj[i];
+		obj = &meson_obj->base;
+
+		seq_printf(m, "   %d: offset=%d pitch=%d, obj: ",
+				i, fb->offsets[i], fb->pitches[i]);
+		seq_printf(m, "%2d (%2d) %pad %p %d\n",
+				obj->name, obj->refcount.refcount.counter,
+				&meson_obj->paddr, meson_obj->vaddr, obj->size);
+	}
+}
+
+int meson_drm_debugfs_show(struct seq_file *m, void *arg)
+{
+	struct drm_info_node *node = (struct drm_info_node *) m->private;
+	struct drm_device *dev = node->minor->dev;
+	struct drm_framebuffer *fb;
+	int ret;
+
+	ret = mutex_lock_interruptible(&dev->mode_config.mutex);
+	if (ret)
+		return ret;
+
+	ret = mutex_lock_interruptible(&dev->struct_mutex);
+	if (ret) {
+		mutex_unlock(&dev->mode_config.mutex);
+		return ret;
+	}
+
+	list_for_each_entry(fb, &dev->mode_config.fb_list, head)
+		meson_drm_fb_describe(fb, m);
+
+	mutex_unlock(&dev->struct_mutex);
+	mutex_unlock(&dev->mode_config.mutex);
+
+	return 0;
+}
+

--- a/drivers/gpu/drm/meson/meson_fb.h
+++ b/drivers/gpu/drm/meson/meson_fb.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Endless Mobile
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Carlo Caione <carlo@endlessm.com>
+ */
+
+#ifndef MESON_FB_H
+#define MESON_FB_H
+
+struct meson_framebuffer {
+	struct drm_framebuffer		fb;
+	struct meson_drm_gem_object	*obj[4];
+};
+#define drm_fb_to_meson_fb(mfb) container_of(mfb, struct meson_framebuffer, fb)
+
+struct drm_fb_helper *meson_fbdev_init(struct drm_device *dev,
+		unsigned int preferred_bpp,
+		unsigned int num_crtc,
+		unsigned int max_conn_count);
+struct drm_framebuffer *meson_fb_create(struct drm_device *dev,
+		struct drm_file *file_priv, struct drm_mode_fb_cmd2 *mode_cmd);
+struct meson_drm_gem_object *meson_drm_get_gem_obj(struct drm_framebuffer *fb,
+		unsigned int plane);
+int meson_drm_debugfs_show(struct seq_file *m, void *arg);
+
+#endif

--- a/drivers/gpu/drm/meson/meson_gem.c
+++ b/drivers/gpu/drm/meson/meson_gem.c
@@ -1,0 +1,433 @@
+/*
+ * Copyright (C) 2016 Endless Mobile
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Carlo Caione <carlo@endlessm.com>
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <linux/dma-buf.h>
+#include <linux/dma-mapping.h>
+
+#include <drm/drmP.h>
+#include <drm/drm.h>
+#include <drm/drm_gem_cma_helper.h>
+#include <drm/drm_vma_manager.h>
+
+#include <drm/meson_drm.h>
+
+#include "meson_priv.h"
+#include "meson_gem.h"
+
+static struct meson_drm_gem_object *meson_drm_gem_init(struct drm_device *dev,
+						       unsigned long size)
+{
+	struct meson_drm_gem_object *meson_gem_obj;
+	struct drm_gem_object *gem_obj;
+	int ret;
+
+	meson_gem_obj = kzalloc(sizeof(*meson_gem_obj), GFP_KERNEL);
+	if (!meson_gem_obj)
+		return ERR_PTR(-ENOMEM);
+
+	gem_obj = &meson_gem_obj->base;
+
+	ret = drm_gem_object_init(dev, gem_obj, size);
+	if (ret) {
+		DRM_ERROR("failed to initialize gem object\n");
+		goto error;
+	}
+
+	ret = drm_gem_create_mmap_offset(gem_obj);
+	if (ret < 0) {
+		drm_gem_object_release(gem_obj);
+		goto error;
+	}
+
+	DRM_DEBUG_KMS("created file object = 0x%x\n", (unsigned int)gem_obj->filp);
+
+	return meson_gem_obj;
+
+error:
+	kfree(meson_gem_obj);
+	return ERR_PTR(ret);
+}
+
+static void meson_drm_gem_scattered_free(struct meson_drm_gem_object *meson_gem_obj,
+					 int page_count)
+{
+	while (page_count--)
+		if (meson_gem_obj->pages[page_count])
+			__free_pages(meson_gem_obj->pages[page_count], 0);
+	drm_free_large(meson_gem_obj->pages);
+}
+
+static int meson_drm_gem_scattered_alloc_buf(struct meson_drm_gem_object *meson_gem_obj)
+{
+	gfp_t gfp = GFP_KERNEL | GFP_DMA | __GFP_NOWARN | __GFP_NORETRY;
+	int count;
+	int ret = -ENOMEM;
+	int i = 0;
+
+	count = meson_gem_obj->size >> PAGE_SHIFT;
+
+	meson_gem_obj->pages = drm_calloc_large(count, sizeof(struct page *));
+	if (!meson_gem_obj->pages) {
+		DRM_ERROR("failed to allocate pages.\n");
+		return -ENOMEM;
+	}
+
+	while (count) {
+		int j, order = __fls(count);
+
+		meson_gem_obj->pages[i] = alloc_pages(gfp, order);
+		while (!meson_gem_obj->pages[i] && order)
+			meson_gem_obj->pages[i] = alloc_pages(gfp, --order);
+
+		if (!meson_gem_obj->pages[i])
+			goto error;
+
+		if (order) {
+			split_page(meson_gem_obj->pages[i], order);
+			j = 1 << order;
+			while (--j)
+				meson_gem_obj->pages[i + j] = meson_gem_obj->pages[i] + j;
+		}
+
+		i += 1 << order;
+		count -= 1 << order;
+	}
+
+	meson_gem_obj->nr_pages = i;
+
+	meson_gem_obj->sgt = drm_prime_pages_to_sg(meson_gem_obj->pages, meson_gem_obj->nr_pages);
+	if (IS_ERR(meson_gem_obj->sgt)) {
+		ret = PTR_ERR(meson_gem_obj->sgt);
+		goto error;
+	}
+
+	return 0;
+
+error:
+	meson_drm_gem_scattered_free(meson_gem_obj, i);
+	return ret;
+}
+
+static int meson_drm_gem_cma_alloc_buf(struct meson_drm_gem_object *meson_gem_obj,
+			 	       struct drm_device *drm)
+{
+	unsigned int nr_pages;
+	int ret = 0;
+
+	nr_pages = meson_gem_obj->size >> PAGE_SHIFT;
+	meson_gem_obj->nr_pages = nr_pages;
+
+	meson_gem_obj->pages = drm_calloc_large(nr_pages, sizeof(struct page *));
+	if (!meson_gem_obj->pages) {
+		DRM_ERROR("failed to allocate pages.\n");
+		return -ENOMEM;
+	}
+
+	meson_gem_obj->sgt = kmalloc(sizeof(struct sg_table), GFP_KERNEL);
+	if (!meson_gem_obj->sgt) {
+		DRM_ERROR("failed to allocate sgt.\n");
+		ret = -ENOMEM;
+		goto err_free;
+	}
+
+	meson_gem_obj->vaddr = dma_alloc_attrs(drm->dev, meson_gem_obj->size,
+					       &meson_gem_obj->paddr,
+					       GFP_KERNEL | __GFP_NOWARN,
+					       &meson_gem_obj->dma_attrs);
+	if (!meson_gem_obj->vaddr) {
+		DRM_ERROR("failed to allocate buffer with size %ld\n", meson_gem_obj->size);
+		ret = -ENOMEM;
+		goto err_sgt_kfree;
+	}
+
+
+	ret = dma_get_sgtable_attrs(drm->dev, meson_gem_obj->sgt, meson_gem_obj->vaddr,
+				    meson_gem_obj->paddr, meson_gem_obj->size,
+				    &meson_gem_obj->dma_attrs);
+	if (ret < 0) {
+		DRM_ERROR("failed to get sgtable.\n");
+		goto err_dma_free;
+	}
+
+	if (drm_prime_sg_to_page_addr_arrays(meson_gem_obj->sgt, meson_gem_obj->pages, NULL,
+				nr_pages)) {
+		DRM_ERROR("invalid sgtable.\n");
+		ret = -EINVAL;
+		goto err_sgt_free;
+	}
+
+	return 0;
+
+err_sgt_free:
+	sg_free_table(meson_gem_obj->sgt);
+err_dma_free:
+	dma_free_attrs(drm->dev, meson_gem_obj->base.size,
+		       meson_gem_obj->vaddr, meson_gem_obj->paddr,
+		       &meson_gem_obj->dma_attrs);
+err_sgt_kfree:
+	kfree(meson_gem_obj->sgt);
+err_free:
+	drm_free_large(meson_gem_obj->pages);
+	return ret;
+}
+
+static int meson_drm_gem_alloc_buf(struct meson_drm_gem_object *meson_gem_obj,
+				   struct drm_device *drm)
+{
+	if (meson_gem_obj->is_scattered)
+		return meson_drm_gem_scattered_alloc_buf(meson_gem_obj);
+
+	return meson_drm_gem_cma_alloc_buf(meson_gem_obj, drm);
+}
+
+static struct meson_drm_gem_object *meson_drm_gem_create(struct drm_device *dev,
+							 unsigned long size,
+							 struct dma_attrs *dma_attrs)
+{
+	struct meson_drm_gem_object *meson_gem_obj;
+	int ret;
+
+	size = round_up(size, PAGE_SIZE);
+
+	meson_gem_obj = meson_drm_gem_init(dev, size);
+	if (IS_ERR(meson_gem_obj))
+		return meson_gem_obj;
+
+	meson_gem_obj->size = size;
+	meson_gem_obj->dma_attrs = *dma_attrs;
+	meson_gem_obj->is_scattered = !dma_get_attr(DMA_ATTR_WRITE_COMBINE, dma_attrs);
+
+	ret = meson_drm_gem_alloc_buf(meson_gem_obj, dev);
+	if (ret < 0) {
+		drm_gem_object_release(&meson_gem_obj->base);
+		kfree(meson_gem_obj);
+		return ERR_PTR(ret);
+	}
+
+	return meson_gem_obj;
+}
+
+static void meson_drm_gem_destroy(struct meson_drm_gem_object *meson_gem_obj)
+{
+	struct drm_gem_object *gem_obj = &meson_gem_obj->base;
+
+	DRM_DEBUG_KMS("handle count = %d\n", gem_obj->handle_count);
+
+	if (meson_gem_obj->vaddr)
+		dma_free_attrs(gem_obj->dev->dev, meson_gem_obj->base.size,
+			       meson_gem_obj->vaddr, meson_gem_obj->paddr,
+			       &meson_gem_obj->dma_attrs);
+
+	/*
+	 * TODO: we do not deal yet with dma_buf imported as a (scattered) gem object
+	 */
+	else if (!gem_obj->import_attach)
+		meson_drm_gem_scattered_free(meson_gem_obj, meson_gem_obj->nr_pages);
+
+	sg_free_table(meson_gem_obj->sgt);
+	kfree(meson_gem_obj->sgt);
+
+	drm_gem_object_release(gem_obj);
+	kfree(meson_gem_obj);
+}
+
+static int meson_drm_gem_handle_create(struct drm_gem_object *obj,
+				       struct drm_file *file_priv,
+				       unsigned int *handle)
+{
+	int ret;
+
+	ret = drm_gem_handle_create(file_priv, obj, handle);
+	if (ret)
+		return ret;
+
+	DRM_DEBUG_KMS("gem handle = 0x%x\n", *handle);
+
+	drm_gem_object_unreference_unlocked(obj);
+
+	return 0;
+}
+
+struct meson_drm_gem_object *meson_drm_gem_create_obj(struct drm_device *dev,
+						      unsigned int size)
+{
+	DEFINE_DMA_ATTRS(dma_attrs);
+
+	dma_set_attr(DMA_ATTR_WRITE_COMBINE, &dma_attrs);
+	size = PAGE_ALIGN(size);
+
+	return meson_drm_gem_create(dev, size, &dma_attrs);
+}
+
+struct meson_drm_gem_object *meson_drm_gem_create_with_handle(struct drm_device *dev,
+							      unsigned int size,
+							      unsigned int *handle,
+							      struct drm_file *file_priv,
+							      struct dma_attrs *dma_attrs)
+{
+	struct meson_drm_gem_object *meson_gem_obj;
+	int ret;
+
+	/* UMP requires a page-aligned size for its buffers. */
+	size = PAGE_ALIGN (size);
+
+	meson_gem_obj = meson_drm_gem_create(dev, size, dma_attrs);
+	if (IS_ERR(meson_gem_obj))
+		return meson_gem_obj;
+
+	ret = meson_drm_gem_handle_create(&meson_gem_obj->base, file_priv, handle);
+	if (ret) {
+		meson_drm_gem_destroy(meson_gem_obj);
+		return ERR_PTR(ret);
+	}
+
+	return meson_gem_obj;
+}
+
+void meson_drm_gem_free_object(struct drm_gem_object *gem_obj)
+{
+	meson_drm_gem_destroy(to_meson_drm_gem_obj(gem_obj));
+}
+
+struct sg_table *meson_drm_gem_get_sg_table(struct drm_gem_object *gem_obj)
+{
+	struct meson_drm_gem_object *meson_gem_obj;
+
+	meson_gem_obj = to_meson_drm_gem_obj(gem_obj);
+
+	return drm_prime_pages_to_sg(meson_gem_obj->pages, meson_gem_obj->nr_pages);
+}
+
+static int meson_drm_gem_scattered_mmap_obj(struct meson_drm_gem_object *meson_gem_obj,
+					    struct vm_area_struct *vma)
+{
+
+	unsigned long addr = vma->vm_start;
+	int i, ret;
+
+	for (i = 0; i < meson_gem_obj->nr_pages; i++) {
+		struct page *page = meson_gem_obj->pages[i];
+
+		ret = vm_insert_pfn(vma, addr, page_to_pfn(page));
+		if (ret)
+			return -EFAULT;
+
+		addr += PAGE_SIZE;
+	}
+
+	return 0;
+}
+
+static int meson_drm_gem_cma_mmap_obj(struct meson_drm_gem_object *meson_gem_obj,
+				      struct vm_area_struct *vma)
+{
+	int ret;
+
+	/*
+	 * Clear the VM_PFNMAP flag that was set by drm_gem_mmap(), and set the
+	 * vm_pgoff (used as a fake buffer offset by DRM) to 0 as we want to map
+	 * the whole buffer.
+	 */
+	vma->vm_flags &= ~VM_PFNMAP;
+	vma->vm_pgoff = 0;
+	vma->vm_page_prot = vm_get_page_prot(vma->vm_flags);
+
+	ret = dma_mmap_attrs(meson_gem_obj->base.dev->dev, vma,
+			     meson_gem_obj->vaddr, meson_gem_obj->paddr,
+			     vma->vm_end - vma->vm_start,
+			     &meson_gem_obj->dma_attrs);
+	if (ret)
+		drm_gem_vm_close(vma);
+
+	return ret;
+}
+
+int meson_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	struct drm_gem_object *gem_obj;
+	struct meson_drm_gem_object *meson_gem_obj;
+	int ret;
+
+	ret = drm_gem_mmap(filp, vma);
+	if (ret)
+		return ret;
+
+	gem_obj = vma->vm_private_data;
+	meson_gem_obj = to_meson_drm_gem_obj(gem_obj);
+
+	vma->vm_page_prot = vm_get_page_prot(vma->vm_flags);
+
+	if (!meson_gem_obj->is_scattered)
+		return meson_drm_gem_cma_mmap_obj(meson_gem_obj, vma);
+
+	return meson_drm_gem_scattered_mmap_obj(meson_gem_obj, vma);
+}
+
+int meson_drm_gem_dumb_create(struct drm_file *file_priv,
+			      struct drm_device *dev,
+			      struct drm_mode_create_dumb *args)
+{
+	struct meson_drm_gem_object *meson_gem_obj;
+	int min_pitch = DIV_ROUND_UP(args->width * args->bpp, 8);
+	DEFINE_DMA_ATTRS(dma_attrs);
+
+	if (args->pitch < min_pitch)
+		args->pitch = min_pitch;
+
+	if (args->size < args->pitch * args->height)
+		args->size = args->pitch * args->height;
+
+	dma_set_attr(DMA_ATTR_WRITE_COMBINE, &dma_attrs);
+
+	meson_gem_obj = meson_drm_gem_create_with_handle(dev, args->size, &args->handle, file_priv, &dma_attrs);
+
+	return PTR_ERR_OR_ZERO(meson_gem_obj);
+}
+
+int meson_drm_gem_dumb_map_offset(struct drm_file *file_priv,
+				  struct drm_device *drm,
+				  uint32_t handle, uint64_t *offset)
+{
+	struct drm_gem_object *gem_obj;
+
+	mutex_lock(&drm->struct_mutex);
+
+	gem_obj = drm_gem_object_lookup(drm, file_priv, handle);
+	if (!gem_obj) {
+		DRM_ERROR("failed to lookup gem object\n");
+		mutex_unlock(&drm->struct_mutex);
+		return -EINVAL;
+	}
+
+	*offset = drm_vma_node_offset_addr(&gem_obj->vma_node);
+
+	drm_gem_object_unreference(gem_obj);
+
+	mutex_unlock(&drm->struct_mutex);
+
+	return 0;
+}
+

--- a/drivers/gpu/drm/meson/meson_gem.h
+++ b/drivers/gpu/drm/meson/meson_gem.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Endless Mobile
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Carlo Caione <carlo@endlessm.com>
+ */
+
+#ifndef __MESON_GEM_PRIME_H__
+#define __MESON_GEM_PRIME_H__
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <drm/drmP.h>
+
+struct meson_drm_gem_object {
+	struct drm_gem_object	base;
+	struct dma_attrs	dma_attrs;
+	struct page		**pages;
+	struct sg_table		*sgt;
+	unsigned long		size;
+	unsigned int		nr_pages;
+	dma_addr_t		paddr;
+	void			*vaddr;
+	bool			is_scattered;
+};
+
+static inline struct meson_drm_gem_object *
+to_meson_drm_gem_obj(struct drm_gem_object *gem_obj)
+{
+	return container_of(gem_obj, struct meson_drm_gem_object, base);
+}
+
+struct meson_drm_gem_object *meson_drm_gem_create_with_handle(
+		struct drm_device *dev,
+		unsigned int size,
+		unsigned int *handle,
+		struct drm_file *file_priv,
+		struct dma_attrs *dma_attrs);
+void meson_drm_gem_free_object(struct drm_gem_object *gem_obj);
+int meson_drm_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf);
+struct sg_table *meson_drm_gem_get_sg_table(struct drm_gem_object *obj);
+int meson_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma);
+struct meson_drm_gem_object *meson_drm_gem_create_obj(struct drm_device *dev,
+		unsigned int size);
+int meson_drm_gem_dumb_create(struct drm_file *file_priv,
+		struct drm_device *dev,
+		struct drm_mode_create_dumb *args);
+int meson_drm_gem_dumb_map_offset(struct drm_file *file_priv,
+		struct drm_device *drm,
+		uint32_t handle,
+		uint64_t *offset);
+
+#endif


### PR DESCRIPTION
[endlessm/eos-shell#6163]
