### PR TITLE
drm/meson: Implent gem_prime_mmap

### DIFF
--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -1288,6 +1288,7 @@ static struct drm_driver meson_driver = {
 	.gem_prime_export	= drm_gem_prime_export,
 	.gem_prime_get_sg_table	= meson_drm_gem_get_sg_table,
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,
+	.gem_prime_mmap     = meson_drm_gem_prime_mmap,
 	.dumb_create        = meson_drm_gem_dumb_create,
 	.dumb_map_offset    = meson_drm_gem_dumb_map_offset,
 	.dumb_destroy       = drm_gem_dumb_destroy,

--- a/drivers/gpu/drm/meson/meson_gem.h
+++ b/drivers/gpu/drm/meson/meson_gem.h
@@ -57,6 +57,8 @@ void meson_drm_gem_free_object(struct drm_gem_object *gem_obj);
 int meson_drm_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf);
 struct sg_table *meson_drm_gem_get_sg_table(struct drm_gem_object *obj);
 int meson_drm_gem_mmap(struct file *filp, struct vm_area_struct *vma);
+int meson_drm_gem_prime_mmap(struct drm_gem_object *obj,
+			     struct vm_area_struct *vma);
 struct meson_drm_gem_object *meson_drm_gem_create_obj(struct drm_device *dev,
 		unsigned int size);
 int meson_drm_gem_dumb_create(struct drm_file *file_priv,


### PR DESCRIPTION
This codepath is used by Mali's glReadPixels() implementation.

I based the implementation on drm_gem_cma_prime_mmap() and
meson_drm_gem_mmap().

[endlessm/eos-shell#6274]
