### PR TITLE
Ship kernel in uboot image directly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian Kernel Team <debian-kernel@lists.debian.org>
 Uploaders: Bastian Blank <waldi@debian.org>, Frederik Schüler <fs@debian.org>, maximilian attems <maks@debian.org>, Ben Hutchings <ben@decadent.org.uk>
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>> 7), cpio, kmod | module-init-tools, python (>= 2.7), lzma [armel], kernel-wedge (>= 2.84), quilt, patchutils, bc, gcc-4.9 [armhf]
+Build-Depends: debhelper (>> 7), cpio, kmod | module-init-tools, python (>= 2.7), lzma [armel], kernel-wedge (>= 2.84), quilt, patchutils, bc, gcc-4.9 [armhf], u-boot-tools, device-tree-compiler
 Build-Depends-Indep: bzip2, xmlto
 Vcs-Svn: svn://svn.debian.org/svn/kernel/dists/trunk/linux/
 Vcs-Browser: http://anonscm.debian.org/viewvc/kernel/dists/trunk/linux/

--- a/debian/rules.real
+++ b/debian/rules.real
@@ -381,7 +381,8 @@ install-image_sh4_$(FEATURESET)_$(FLAVOUR)_plain_image:
 ifneq ($(filter armel armhf,$(ARCH)),)
 install-image_$(ARCH)_$(FEATURESET)_$(FLAVOUR)_plain_image: DTB_INSTALL_DIR = /usr/lib/linux-image-$(REAL_VERSION)
 install-image_$(ARCH)_$(FEATURESET)_$(FLAVOUR)_plain_image:
-	install -m644 '$(DIR)/arch/$(KERNEL_ARCH)/boot/zImage' $(INSTALL_DIR)/vmlinuz-$(REAL_VERSION)
+	cp amlogic.its $(DIR)
+	cd $(DIR) && mkimage -f amlogic.its ../../../$(INSTALL_DIR)/vmlinuz-$(REAL_VERSION)
 	+$(MAKE_CLEAN) -C $(DIR) dtbs
 	shopt -s nullglob ; for i in $(DIR)/arch/arm/boot/dts/*.dtb ; do \
 		install -D -m644 $$i '$(PACKAGE_DIR)'/'$(DTB_INSTALL_DIR)'/$$(basename $$i) ; \


### PR DESCRIPTION
Instead of shipping a vmlinuz file and later packaging it into a uboot image
in the image builder, we create and ship the uImage directly.

This implements an auto update to the new kernel when updating the kernel
package on a running system.

We stick with the vmlinuz naming scheme to avoid fighting against a
multitude of other Debian bits that expect this name.

https://phabricator.endlessm.com/T1404
