### PR TITLE
userns: Allow PR_CAPBSET_DROP in a user namespace.

### DIFF
--- a/security/commoncap.c
+++ b/security/commoncap.c
@@ -843,7 +843,7 @@ int cap_task_setnice(struct task_struct *p, int nice)
  */
 static long cap_prctl_drop(struct cred *new, unsigned long cap)
 {
-	if (!capable(CAP_SETPCAP))
+	if (!ns_capable(current_user_ns(), CAP_SETPCAP))
 		return -EPERM;
 	if (!cap_valid(cap))
 		return -EINVAL;


### PR DESCRIPTION
https://phabricator.endlessm.com/T15398