### PR TITLE
Bluetooth: sco: Drop sco_pkt_type from sockaddr_sco

### DIFF
--- a/include/net/bluetooth/sco.h
+++ b/include/net/bluetooth/sco.h
@@ -37,7 +37,6 @@
 struct sockaddr_sco {
 	sa_family_t	sco_family;
 	bdaddr_t	sco_bdaddr;
-	__u16		sco_pkt_type;
 };
 
 /* SCO socket options */

--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -479,7 +479,6 @@ static int sco_sock_bind(struct socket *sock, struct sockaddr *addr, int alen)
 	}
 
 	bacpy(&bt_sk(sk)->src, &sa.sco_bdaddr);
-	sco_pi(sk)->pkt_type = sa.sco_pkt_type;
 
 	sk->sk_state = BT_BOUND;
 
@@ -517,7 +516,6 @@ static int sco_sock_connect(struct socket *sock, struct sockaddr *addr, int alen
 
 	/* Set destination address and psm */
 	bacpy(&bt_sk(sk)->dst, &sa.sco_bdaddr);
-	sco_pi(sk)->pkt_type = sa.sco_pkt_type;
 
 	err = sco_connect(sk);
 	if (err)
@@ -641,7 +639,6 @@ static int sco_sock_getname(struct socket *sock, struct sockaddr *addr, int *len
 		bacpy(&sa->sco_bdaddr, &bt_sk(sk)->dst);
 	else
 		bacpy(&sa->sco_bdaddr, &bt_sk(sk)->src);
-	sa->sco_pkt_type = sco_pi(sk)->pkt_type;
 
 	return 0;
 }


### PR DESCRIPTION
This is not part of the upstream Linux kernel ABI, so I'm guessing it is
something needed by bluedroid (Android's official Bluetooth stack since
Android 4.2). We are running a Linux userspace so lets stick to the
upstream ABI.

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T20229