### PR TITLE
drm/meson: Disable CVBS connectors by default

### DIFF
--- a/drivers/gpu/drm/meson/meson_drv.c
+++ b/drivers/gpu/drm/meson/meson_drv.c
@@ -55,7 +55,7 @@ enum meson_connectors {
 	MESON_CONNECTORS_CVBS_NTSC = 0x2,
 	MESON_CONNECTORS_CVBS_PAL  = 0x4,
 };
-static char enabled_connectors = 0;
+static char enabled_connectors = 1;
 module_param(enabled_connectors, byte, S_IRUGO | S_IWUSR);
 
 #define DRIVER_NAME "meson"


### PR DESCRIPTION
They can be enabled again through the "enabled_connectors" module
parameter, by setting it to 0 (auto-detect, all connectors enabled), or
by combining the following values using a logic OR:

  0x1 HDMI
  0x2 CVBS_NTSC
  0x4 CVBS_PAL

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessm.com>

https://phabricator.endlessm.com/T25451